### PR TITLE
Add super admin role with elevated access

### DIFF
--- a/FIREBASE_INTEGRATION.md
+++ b/FIREBASE_INTEGRATION.md
@@ -6,7 +6,7 @@ This document outlines the Firebase services integrated into the NextLevel Renta
 
 ### 1. Firebase Authentication
 - **Email/Password Authentication**: Users can sign up and sign in
-- **User Role Management**: Tenant and Admin roles with Firestore-based permissions
+- **User Role Management**: Tenant, Admin, and Super Admin roles with Firestore-based permissions
 - **Auth State Management**: Real-time authentication state tracking
 
 ### 2. Cloud Firestore Database
@@ -148,16 +148,16 @@ messagingUtils.onMessage((payload) => {
 ## 🔒 Security Rules
 
 ### Firestore Rules
-- Users can only read/write their own user document
-- Properties are readable by all authenticated users, writable by admins only
-- Maintenance requests are readable by the tenant who created them and admins
-- Lease documents and payments follow similar tenant/admin access patterns
+- Users can only read/write their own user document, with super admins able to manage every profile
+- Properties are readable by all authenticated users, writable by admins and super admins
+- Maintenance requests are readable by the tenant who created them, admins, and super admins
+- Lease documents and payments follow similar tenant/admin/super-admin access patterns
 
 ### Storage Rules
-- Users can upload their own profile images
-- Property images are readable by all, writable by admins
-- Maintenance request attachments are accessible by the requesting tenant and admins
-- Lease documents are readable by tenants, writable by admins
+- Users can upload their own profile images, while super admins can manage any profile asset
+- Property images are readable by all, writable by admins and super admins
+- Maintenance request attachments are accessible by the requesting tenant, admins, and super admins
+- Lease documents are readable by tenants, admins, and super admins, writable by admins and super admins
 
 ## 📊 Analytics Events
 

--- a/README.md
+++ b/README.md
@@ -178,11 +178,11 @@ For support and inquiries:
 
 ### Role Seeding Script
 
-Use `scripts/seed-roles.js` to create the required Firestore documents for your admin and tenant users. Install Firebase Admin locally (`npm install firebase-admin --save-dev`), then run:
+Use `scripts/seed-roles.js` to create the required Firestore documents for your super admin, admin, and tenant users. Install Firebase Admin locally (`npm install firebase-admin --save-dev`), then run:
 
 ```bash
 node scripts/seed-roles.js path/to/serviceAccountKey.json
 ```
 
-Update the placeholder UIDs in the script before executing it; the values should match the Firebase Authentication UIDs for your accounts. You can re-run the script any time you add new users.
+Update the placeholder UIDs in the script before executing it; the values should match the Firebase Authentication UIDs for your super admin, admin, and tenant accounts. You can re-run the script any time you add new users.
 

--- a/components/Auth/AuthGuard.tsx
+++ b/components/Auth/AuthGuard.tsx
@@ -43,6 +43,7 @@ const LoadingState = () => (
 export default function AuthGuard({ allowedRoles, children }: AuthGuardProps) {
   const router = useRouter();
   const { user, role, loading } = useAuth();
+  const isSuperAdmin = role === 'super-admin';
 
   useEffect(() => {
     if (loading) return;
@@ -56,12 +57,12 @@ export default function AuthGuard({ allowedRoles, children }: AuthGuardProps) {
       return;
     }
 
-    if (allowedRoles && role && !allowedRoles.includes(role)) {
+    if (allowedRoles && role && !allowedRoles.includes(role) && !isSuperAdmin) {
       void router.replace('/');
     }
-  }, [allowedRoles, loading, role, router, user]);
+  }, [allowedRoles, isSuperAdmin, loading, role, router, user]);
 
-  const roleRestricted = allowedRoles && role && !allowedRoles.includes(role);
+  const roleRestricted = Boolean(allowedRoles && role && !allowedRoles.includes(role) && !isSuperAdmin);
 
   if (loading || !user || roleRestricted) {
     return <LoadingState />;

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -16,6 +16,7 @@ export default function Header() {
   const isLanding = router.pathname === '/';
   const isPortalRoute = router.pathname.startsWith('/portal');
   const isAdminRoute = router.pathname.startsWith('/admin');
+  const hasAdminAccess = role === 'admin' || role === 'super-admin';
 
   const handleSignOut = useCallback(async () => {
     try {
@@ -26,7 +27,12 @@ export default function Header() {
     }
   }, [router, signOutUser]);
 
-  const dashboardHref = role === 'admin' ? '/admin' : '/portal';
+  const dashboardHref = hasAdminAccess ? '/admin' : '/portal';
+  const dashboardLabel = hasAdminAccess
+    ? role === 'super-admin'
+      ? 'Super Admin Console'
+      : 'Admin Console'
+    : 'Tenant Portal';
   const showLandingLinks = isLanding;
 
   return (
@@ -55,7 +61,7 @@ export default function Header() {
                   isPortalRoute || isAdminRoute ? ' filter-chip--active' : ''
                 }`}
               >
-                {role === 'admin' ? 'Admin Console' : 'Tenant Portal'}
+                {dashboardLabel}
               </Link>
               <button type="button" className="ghost-button" onClick={() => void handleSignOut()}>
                 Sign out

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
 import { doc, getDoc, type DocumentData } from 'firebase/firestore';
 import { getFirebaseAuth, getFirestoreClient } from '@/lib/firebase';
 
-export type UserRole = 'admin' | 'tenant';
+export type UserRole = 'admin' | 'tenant' | 'super-admin';
 
 export type UserProfile = {
   id: string;

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,47 +3,71 @@ service cloud.firestore {
   match /databases/{database}/documents {
     // Users collection - users can read/write their own data
     match /users/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && (
+        request.auth.uid == userId ||
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'super-admin'
+        )
+      );
     }
     
     // Properties collection - admins can read/write, tenants can read
     match /properties/{propertyId} {
       allow read: if request.auth != null;
-      allow write: if request.auth != null && 
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+      allow write: if request.auth != null && (
+        let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+        callerRole == 'admin' || callerRole == 'super-admin'
+      );
     }
     
     // Maintenance requests - tenants can create/read their own, admins can read/write all
     match /maintenanceRequests/{requestId} {
       allow read: if request.auth != null && (
         resource.data.tenantId == request.auth.uid ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'admin' || callerRole == 'super-admin'
+        )
       );
       allow create: if request.auth != null && request.auth.uid == resource.data.tenantId;
       allow update: if request.auth != null && (
         resource.data.tenantId == request.auth.uid ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'admin' || callerRole == 'super-admin'
+        )
       );
     }
-    
+
     // Lease documents - tenants can read their own, admins can read/write all
     match /leaseDocuments/{documentId} {
       allow read: if request.auth != null && (
         resource.data.tenantId == request.auth.uid ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'admin' || callerRole == 'super-admin'
+        )
       );
-      allow write: if request.auth != null && 
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+      allow write: if request.auth != null && (
+        let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+        callerRole == 'admin' || callerRole == 'super-admin'
+      );
     }
-    
+
     // Payment history - tenants can read their own, admins can read/write all
     match /payments/{paymentId} {
       allow read: if request.auth != null && (
         resource.data.tenantId == request.auth.uid ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'admin' || callerRole == 'super-admin'
+        )
       );
-      allow write: if request.auth != null && 
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+      allow write: if request.auth != null && (
+        let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+        callerRole == 'admin' || callerRole == 'super-admin'
+      );
     }
   }
 }

--- a/lib/firebase-utils.ts
+++ b/lib/firebase-utils.ts
@@ -43,7 +43,7 @@ import {
 
 // Types
 export interface UserRole {
-  role: 'tenant' | 'admin';
+  role: 'tenant' | 'admin' | 'super-admin';
   displayName?: string;
   email?: string;
   propertyIds?: string[];

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -48,6 +48,6 @@ const AdminPage: NextPageWithAuth = () => {
 };
 
 AdminPage.requireAuth = true;
-AdminPage.allowedRoles = ['admin'];
+AdminPage.allowedRoles = ['admin', 'super-admin'];
 
 export default AdminPage;

--- a/pages/portal.tsx
+++ b/pages/portal.tsx
@@ -83,6 +83,6 @@ const PortalPage: NextPageWithAuth = () => {
 };
 
 PortalPage.requireAuth = true;
-PortalPage.allowedRoles = ['tenant', 'admin'];
+PortalPage.allowedRoles = ['tenant', 'admin', 'super-admin'];
 
 export default PortalPage;

--- a/scripts/seed-roles.js
+++ b/scripts/seed-roles.js
@@ -29,6 +29,14 @@ const seedUsers = [
     }
   },
   {
+    uid: 'REPLACE_WITH_SUPER_ADMIN_UID',
+    data: {
+      displayName: 'Jordan Blake',
+      email: 'jordan@nxtlevelmngmnt.com',
+      role: 'super-admin'
+    }
+  },
+  {
     uid: 'REPLACE_WITH_TENANT_UID',
     data: {
       displayName: 'Morgan Rivera',

--- a/storage.rules
+++ b/storage.rules
@@ -3,25 +3,39 @@ service firebase.storage {
   match /b/{bucket}/o {
     // Users can upload their own profile images
     match /users/{userId}/profile/{allPaths=**} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && (
+        request.auth.uid == userId ||
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'super-admin'
+        )
+      );
     }
     
     // Property images - admins can upload, everyone can read
     match /properties/{propertyId}/{allPaths=**} {
       allow read: if request.auth != null;
-      allow write: if request.auth != null && 
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+      allow write: if request.auth != null && (
+        let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+        callerRole == 'admin' || callerRole == 'super-admin'
+      );
     }
     
     // Maintenance request attachments - tenants can upload for their requests, admins can read/write all
     match /maintenanceRequests/{requestId}/{allPaths=**} {
       allow read: if request.auth != null && (
         resource.metadata.tenantId == request.auth.uid ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'admin' || callerRole == 'super-admin'
+        )
       );
       allow write: if request.auth != null && (
         request.resource.metadata.tenantId == request.auth.uid ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'admin' || callerRole == 'super-admin'
+        )
       );
     }
     
@@ -29,10 +43,15 @@ service firebase.storage {
     match /leaseDocuments/{documentId}/{allPaths=**} {
       allow read: if request.auth != null && (
         resource.metadata.tenantId == request.auth.uid ||
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
+        (
+          let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+          callerRole == 'admin' || callerRole == 'super-admin'
+        )
       );
-      allow write: if request.auth != null && 
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+      allow write: if request.auth != null && (
+        let callerRole = get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+        callerRole == 'admin' || callerRole == 'super-admin'
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary
- introduce a new `super-admin` role across the authentication context, shared utilities, route guard, and navigation so elevated users can access both admin and tenant areas without restrictions
- expand Firestore and Storage security rules plus the role seeding script to recognize super admins, and document the role across the README and Firebase integration guide

## Testing
- `npm run lint` *(fails: local npm registry blocks installing Next.js, so the `next` binary is unavailable)*
- `npm run build` *(fails: local npm registry blocks installing Next.js, so the `next` binary is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cf074b4160832e92915fb43f5bc6e5