### PR TITLE
Fix maintenance request rule create check

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,7 +19,7 @@ service cloud.firestore {
         resource.data.tenantId == request.auth.uid ||
         get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'
       );
-      allow create: if request.auth != null && request.auth.uid == resource.data.tenantId;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.tenantId;
       allow update: if request.auth != null && (
         resource.data.tenantId == request.auth.uid ||
         get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin'


### PR DESCRIPTION
## Summary
- update the maintenance request creation rule to validate against the incoming request payload

## Testing
- npm run emulators -- --only firestore --project demo-project *(fails: firebase CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b979d65c832e8817f09176b658de