### PR TITLE
Fix login page nested main landmark

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -59,7 +59,7 @@ export default function LoginPage() {
       <Head>
         <title>Sign in - Next Level Rentals</title>
       </Head>
-      <main className="auth">
+      <div className="auth">
         <section className="auth-card" aria-labelledby="loginHeading">
           <div className="auth-card__header">
             <h1 id="loginHeading">Welcome back</h1>
@@ -103,7 +103,7 @@ export default function LoginPage() {
             <Link href="mailto:management@nxtlevelrentals.com">Contact the management team</Link>
           </div>
         </section>
-      </main>
+      </div>
       <style jsx>{`
         .auth {
           display: flex;


### PR DESCRIPTION
## Summary
- replace the login view's inner <main> with a div to avoid nested landmarks while keeping styling intact
- confirmed other pages continue to rely on the SiteLayout main so there is a single main landmark per page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b97d94b4832eb0c639db504de5c0