### PR TITLE
Add shared date formatter for portal and admin views

### DIFF
--- a/components/Admin/DocumentQueue.tsx
+++ b/components/Admin/DocumentQueue.tsx
@@ -1,5 +1,7 @@
 import type { DocumentTask } from '@/data/admin';
 
+import { formatLocalDate } from '@/lib/date';
+
 type DocumentQueueProps = {
   tasks: DocumentTask[];
 };
@@ -26,7 +28,7 @@ export default function DocumentQueue({ tasks }: DocumentQueueProps) {
                 </div>
                 <div>
                   <dt>Received</dt>
-                  <dd>{new Date(task.receivedOn).toLocaleDateString()}</dd>
+                  <dd>{formatLocalDate(task.receivedOn)}</dd>
                 </div>
               </dl>
               <div className="document-queue__actions">

--- a/components/Admin/TenantPortfolioTable.tsx
+++ b/components/Admin/TenantPortfolioTable.tsx
@@ -1,5 +1,7 @@
 import type { TenantSummary } from '@/data/admin';
 
+import { formatLocalDate } from '@/lib/date';
+
 type TenantPortfolioTableProps = {
   tenants: TenantSummary[];
 };
@@ -28,7 +30,7 @@ export default function TenantPortfolioTable({ tenants }: TenantPortfolioTablePr
                 <tr key={tenant.id}>
                   <th scope="row">{tenant.name}</th>
                   <td>{tenant.unit}</td>
-                  <td>{new Date(tenant.leaseEnd).toLocaleDateString()}</td>
+                  <td>{formatLocalDate(tenant.leaseEnd)}</td>
                   <td>{tenant.balance === 0 ? 'Paid' : `$${tenant.balance.toFixed(2)}`}</td>
                   <td>
                     <span className={`tag ${tenant.autopay ? 'tag--success' : 'tag--warning'}`}>

--- a/components/Admin/WorkOrderTable.tsx
+++ b/components/Admin/WorkOrderTable.tsx
@@ -1,5 +1,7 @@
 import type { WorkOrder } from '@/data/admin';
 
+import { formatLocalDate } from '@/lib/date';
+
 type WorkOrderTableProps = {
   workOrders: WorkOrder[];
 };
@@ -28,7 +30,7 @@ export default function WorkOrderTable({ workOrders }: WorkOrderTableProps) {
                 <tr key={order.id}>
                   <th scope="row">{order.summary}</th>
                   <td>{order.unit}</td>
-                  <td>{new Date(order.submittedOn).toLocaleDateString()}</td>
+                  <td>{formatLocalDate(order.submittedOn)}</td>
                   <td>{order.status}</td>
                   <td>
                     <span className={`tag ${order.priority === 'High' ? 'tag--warning' : 'tag--info'}`}>

--- a/components/Portal/DashboardHighlights.tsx
+++ b/components/Portal/DashboardHighlights.tsx
@@ -1,10 +1,9 @@
 import type { DashboardMetrics } from '@/data/portal';
 
+import { formatLocalDate } from '@/lib/date';
+
 const formatCurrency = (value: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
-
-const formatDate = (value: string) =>
-  new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 
 type DashboardHighlightsProps = {
   metrics: DashboardMetrics;
@@ -15,7 +14,7 @@ export default function DashboardHighlights({ metrics }: DashboardHighlightsProp
     {
       label: 'Current Balance',
       value: formatCurrency(metrics.currentBalance),
-      meta: `Due ${formatDate(metrics.dueDate)}`
+      meta: `Due ${formatLocalDate(metrics.dueDate, { month: 'short', day: 'numeric', year: 'numeric' })}`
     },
     {
       label: 'AutoPay',
@@ -24,13 +23,17 @@ export default function DashboardHighlights({ metrics }: DashboardHighlightsProp
     },
     {
       label: 'Next Inspection',
-      value: formatDate(metrics.nextInspection),
+      value: formatLocalDate(metrics.nextInspection, { month: 'short', day: 'numeric', year: 'numeric' }),
       meta: 'A reminder will be sent 72 hours prior'
     },
     {
       label: 'Lease Renewal',
-      value: formatDate(metrics.leaseRenewalDate),
-      meta: `Last payment ${formatDate(metrics.lastPaymentDate)} · ${formatCurrency(metrics.lastPaymentAmount)}`
+      value: formatLocalDate(metrics.leaseRenewalDate, { month: 'short', day: 'numeric', year: 'numeric' }),
+      meta: `Last payment ${formatLocalDate(metrics.lastPaymentDate, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+      })} · ${formatCurrency(metrics.lastPaymentAmount)}`
     }
   ];
 

--- a/components/Portal/LeaseDocuments.tsx
+++ b/components/Portal/LeaseDocuments.tsx
@@ -1,5 +1,7 @@
 import type { LeaseDocument } from '@/data/portal';
 
+import { formatLocalDate } from '@/lib/date';
+
 type LeaseDocumentsProps = {
   documents: LeaseDocument[];
 };
@@ -17,7 +19,7 @@ export default function LeaseDocuments({ documents }: LeaseDocumentsProps) {
             <div className="document-row" key={document.id}>
               <div className="document-row__info">
                 <span className="document-row__title">{document.title}</span>
-                <span className="document-row__meta">Updated {new Date(document.updatedOn).toLocaleDateString()}</span>
+                <span className="document-row__meta">Updated {formatLocalDate(document.updatedOn)}</span>
               </div>
               <a className="outline-button" href={document.downloadUrl}>
                 Download

--- a/components/Portal/MaintenanceRequests.tsx
+++ b/components/Portal/MaintenanceRequests.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import type { MaintenanceRequest } from '@/data/portal';
 
+import { formatLocalDate } from '@/lib/date';
+
 type MaintenanceRequestsProps = {
   requests: MaintenanceRequest[];
   activeStatus: MaintenanceRequest['status'] | 'All';
@@ -49,7 +51,7 @@ export default function MaintenanceRequests({ requests, activeStatus, onStatusCh
           {filtered.map((request) => (
             <article className="maintenance-card" key={request.id}>
               <div className="maintenance-card__meta">
-                <span>{new Date(request.submittedOn).toLocaleDateString()}</span>
+                <span>{formatLocalDate(request.submittedOn)}</span>
                 <span className={statusColors[request.status]}>{request.status}</span>
               </div>
               <h3 className="maintenance-card__title">{request.title}</h3>

--- a/components/Portal/PaymentHistory.tsx
+++ b/components/Portal/PaymentHistory.tsx
@@ -1,10 +1,9 @@
 import type { PaymentRecord } from '@/data/portal';
 
+import { formatLocalDate } from '@/lib/date';
+
 const formatCurrency = (value: number) =>
   new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 }).format(value);
-
-const formatDate = (value: string) =>
-  new Date(value).toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
 
 type PaymentHistoryProps = {
   payments: PaymentRecord[];
@@ -38,7 +37,7 @@ export default function PaymentHistory({ payments }: PaymentHistoryProps) {
             <tbody>
               {payments.map((payment) => (
                 <tr key={payment.id}>
-                  <td>{formatDate(payment.date)}</td>
+                  <td>{formatLocalDate(payment.date, { month: 'long', day: 'numeric', year: 'numeric' })}</td>
                   <td>{formatCurrency(payment.amount)}</td>
                   <td>
                     <span className={statusTagClass[payment.status]}>{payment.status}</span>

--- a/components/Portal/PortalHero.tsx
+++ b/components/Portal/PortalHero.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 
+import { formatLocalDate } from '@/lib/date';
+
 type PortalHeroProps = {
   residentName: string;
   propertyName: string;
@@ -32,11 +34,8 @@ export default function PortalHero({ residentName, propertyName, unit, nextDueDa
             <strong>Unit:</strong> {unit}
           </div>
           <div>
-            <strong>Next rent due:</strong> {new Date(nextDueDate).toLocaleDateString(undefined, {
-              month: 'long',
-              day: 'numeric',
-              year: 'numeric'
-            })}
+            <strong>Next rent due:</strong>{' '}
+            {formatLocalDate(nextDueDate, { month: 'long', day: 'numeric', year: 'numeric' })}
           </div>
         </div>
       </div>

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,61 @@
+const CALENDAR_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseCalendarDateString(value: string): Date | null {
+  const normalized = value.trim();
+
+  if (!CALENDAR_DATE_REGEX.test(normalized)) {
+    return null;
+  }
+
+  const [year, month, day] = normalized.split('-').map(Number);
+
+  if ([year, month, day].some((part) => Number.isNaN(part))) {
+    return null;
+  }
+
+  const date = new Date(year, month - 1, day);
+
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function normalizeDate(value: string | number | Date): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    const calendarDate = parseCalendarDateString(trimmed);
+
+    if (calendarDate) {
+      return calendarDate;
+    }
+
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  return null;
+}
+
+/**
+ * Formats calendar dates without introducing timezone shifts for YYYY-MM-DD inputs.
+ */
+export function formatLocalDate(
+  value: string | number | Date,
+  options?: Intl.DateTimeFormatOptions,
+  locales?: Intl.LocalesArgument
+): string {
+  const date = normalizeDate(value);
+
+  if (!date) {
+    return '';
+  }
+
+  return new Intl.DateTimeFormat(locales, options).format(date);
+}


### PR DESCRIPTION
## Summary
- add a shared `formatLocalDate` helper that parses calendar dates without introducing timezone shifts
- update portal and admin UI components to format dates through the new helper for consistent rendering

## Testing
- npm run lint *(fails: `next` command not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b9813678832ea453fd1523c51134