### PR TITLE
Add GoHighLevel Properties custom-object sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,26 @@ GEMINI_API_KEY=
 # all email/communications. Private Integration Token + location id.
 GHL_API_KEY=pit-
 GHL_LOCATION_ID=
+
+# GHL "Properties" custom object sync.
+# Run `npm run discover:ghl-properties` to print your object key + field schema.
+# Leave GHL_PROPERTY_OBJECT_KEY blank to auto-detect (matches an object whose
+# name/key looks like "propert…"). GHL_OBJECTS_API_VERSION overrides the API
+# version header only if the default (2021-07-28) returns errors.
+GHL_OBJECTS_API_VERSION=
+GHL_PROPERTY_OBJECT_KEY=
+# Optional: pin exact field ids/keys (else auto-detected by name). See discover script.
+# GHL_PROP_FIELD_NAME=
+# GHL_PROP_FIELD_ADDRESS=
+# GHL_PROP_FIELD_DESCRIPTION=
+# GHL_PROP_FIELD_RENT=
+# GHL_PROP_FIELD_BEDROOMS=
+# GHL_PROP_FIELD_BATHROOMS=
+# GHL_PROP_FIELD_SQFT=
+# GHL_PROP_FIELD_AVAILABLE=
+# GHL_PROP_FIELD_IMAGES=
+# GHL_PROP_FIELD_AMENITIES=
+
+# Properties sync from GHL and the app is read-only for them. Set to "true" to
+# re-enable in-app manual property creation (/api/admin/create-property).
+ALLOW_MANUAL_PROPERTY=

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ yarn-error.log*
 .env*.local
 *.log
 
+# Service account / admin SDK private keys — NEVER commit
+*firebase-adminsdk*.json
+serviceAccount*.json
+*-service-account*.json
+gcloud-key*.json
+
 # Firebase deployment artifacts
 .firebase/
 

--- a/components/Landing/FeaturedPropertiesSection.tsx
+++ b/components/Landing/FeaturedPropertiesSection.tsx
@@ -1,0 +1,209 @@
+import Link from 'next/link';
+
+// Local prop type (kept independent of the server-only properties-public helper
+// so this client component never pulls firebase-admin into the browser bundle).
+export type LandingProperty = {
+  id: string;
+  name: string;
+  address: string;
+  description: string;
+  images: string[];
+  bedrooms: number;
+  bathrooms: number;
+  squareFeet: number;
+  rent: number;
+};
+
+type Props = {
+  properties: LandingProperty[];
+};
+
+const PLACEHOLDER_IMAGE =
+  'https://images.unsplash.com/photo-1568605114967-8130f3a36994?auto=format&fit=crop&w=1200&q=80';
+
+function formatRent(rent: number): string {
+  if (!rent) return 'Contact for pricing';
+  return `$${rent.toLocaleString()}/mo`;
+}
+
+export default function FeaturedPropertiesSection({ properties }: Props) {
+  // Nothing to show (e.g. before the first GHL sync) — render nothing.
+  if (!properties || properties.length === 0) return null;
+
+  return (
+    <section className="featured-properties" id="properties" aria-labelledby="featuredPropertiesHeading">
+      <div className="featured-properties__inner">
+        <div className="featured-properties__header">
+          <p className="section-eyebrow">Available now</p>
+          <h2 id="featuredPropertiesHeading">Explore our available rentals</h2>
+          <p>
+            Browse current openings managed by Next Level Rentals. Found a place you love? Sign in or reach out to start
+            your application.
+          </p>
+        </div>
+
+        <div className="featured-properties__grid" role="list">
+          {properties.map((property) => (
+            <article className="property-card" key={property.id} role="listitem">
+              <div className="property-card__image">
+                {/* Plain img keeps arbitrary GHL/Storage image hosts working without next/image config. */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={property.images?.[0] || PLACEHOLDER_IMAGE} alt={property.name} loading="lazy" />
+              </div>
+              <div className="property-card__body">
+                <h3>{property.name}</h3>
+                {property.address && <p className="property-card__address">{property.address}</p>}
+                <div className="property-card__details">
+                  {property.bedrooms > 0 && <span>{property.bedrooms} Bed</span>}
+                  {property.bathrooms > 0 && <span>{property.bathrooms} Bath</span>}
+                  {property.squareFeet > 0 && <span>{property.squareFeet.toLocaleString()} SqFt</span>}
+                </div>
+                {property.description && (
+                  <p className="property-card__description">{property.description}</p>
+                )}
+                <div className="property-card__footer">
+                  <span className="property-card__rent">{formatRent(property.rent)}</span>
+                  <Link href="/login" className="property-card__cta">
+                    Inquire
+                    <span aria-hidden="true">&gt;</span>
+                  </Link>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      <style jsx>{`
+        .featured-properties {
+          padding: clamp(3.5rem, 7vw, 5rem) 1.5rem;
+          background: var(--color-surface);
+        }
+
+        .featured-properties__inner {
+          max-width: var(--max-width);
+          margin: 0 auto;
+          display: grid;
+          gap: clamp(2rem, 6vw, 3rem);
+        }
+
+        .featured-properties__header {
+          max-width: 640px;
+        }
+
+        .featured-properties__header h2 {
+          font-size: clamp(2rem, 4vw, 2.5rem);
+          color: var(--color-text);
+          margin-bottom: 0.75rem;
+        }
+
+        .featured-properties__header p {
+          color: var(--color-muted);
+          line-height: 1.7;
+        }
+
+        .featured-properties__grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+          gap: 1.5rem;
+        }
+
+        .property-card {
+          background: var(--color-surface-elevated);
+          border-radius: var(--radius-lg);
+          border: 1px solid rgba(15, 118, 110, 0.12);
+          box-shadow: var(--shadow-sm);
+          overflow: hidden;
+          display: flex;
+          flex-direction: column;
+          transition: transform 0.2s ease;
+        }
+
+        .property-card:hover {
+          transform: translateY(-4px);
+        }
+
+        .property-card__image {
+          height: 200px;
+          background: var(--color-surface);
+        }
+
+        .property-card__image img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: block;
+        }
+
+        .property-card__body {
+          padding: 1.5rem;
+          display: grid;
+          gap: 0.5rem;
+          flex: 1;
+        }
+
+        .property-card__body h3 {
+          font-size: 1.2rem;
+          color: var(--color-text);
+          margin: 0;
+        }
+
+        .property-card__address {
+          font-size: 0.875rem;
+          color: var(--color-muted);
+          margin: 0;
+        }
+
+        .property-card__details {
+          display: flex;
+          gap: 1rem;
+          font-size: 0.85rem;
+          color: var(--color-muted);
+          margin: 0.25rem 0;
+        }
+
+        .property-card__description {
+          color: var(--color-muted);
+          line-height: 1.6;
+          font-size: 0.9rem;
+          display: -webkit-box;
+          -webkit-line-clamp: 3;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+
+        .property-card__footer {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-top: auto;
+          padding-top: 1rem;
+          border-top: 1px solid rgba(15, 118, 110, 0.12);
+        }
+
+        .property-card__rent {
+          font-weight: 700;
+          color: var(--color-text);
+          font-size: 1.1rem;
+        }
+
+        .property-card__cta {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.4rem;
+          font-weight: 600;
+          color: var(--color-primary);
+        }
+
+        .property-card__cta span {
+          transition: transform 0.2s ease;
+        }
+
+        .property-card__cta:hover span,
+        .property-card__cta:focus span {
+          transform: translateX(4px);
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/components/Portal/TenantPortal.tsx
+++ b/components/Portal/TenantPortal.tsx
@@ -28,6 +28,7 @@ export default function TenantPortal() {
     // Use our new hook for data
     const {
         lease,
+        property,
         payments,
         maintenanceRequests,
         metrics: realMetrics,
@@ -107,7 +108,7 @@ export default function TenantPortal() {
         <>
             <PortalHero
                 residentName={profile?.displayName || tenantDashboard.residentName}
-                propertyName={tenantDashboard.propertyName} // TODO: Fetch Property Name
+                propertyName={property?.name || tenantDashboard.propertyName}
                 unit={profile?.unit || tenantDashboard.unit}
                 nextDueDate={metrics.dueDate}
             />

--- a/firebase.json
+++ b/firebase.json
@@ -13,7 +13,8 @@
     "ignore": [
       "firebase.json",
       "**/.*",
-      "**/node_modules/**"
+      "**/node_modules/**",
+      "**/*firebase-adminsdk*.json"
     ],
     "frameworksBackend": {
       "region": "us-central1"

--- a/hooks/usePortalData.ts
+++ b/hooks/usePortalData.ts
@@ -45,10 +45,12 @@ export function usePortalData(): PortalData {
             const leases = await leaseUtils.getLeasesByTenant(user.uid);
             const activeLease = (leases.find(l => l.isActive && l.status === 'active') || leases[0] || null) as unknown as Lease;
 
-            // 2. Fetch Property Details if we have a lease
+            // 2. Fetch Property Details. Prefer the lease's propertyId; fall back
+            //    to the tenant's first assigned property (e.g. GHL-synced).
             let property: Property | null = null;
-            if (activeLease) {
-                const p = await propertyUtils.getProperty(activeLease.propertyId);
+            const propertyId = activeLease?.propertyId || profile.propertyIds?.[0];
+            if (propertyId) {
+                const p = await propertyUtils.getProperty(propertyId);
                 if (p) {
                     property = p as unknown as Property;
                 }

--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -1,31 +1,53 @@
+import { existsSync } from 'fs';
 import * as admin from 'firebase-admin';
+import { getApps, initializeApp, cert, applicationDefault, type App } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getAuth } from 'firebase-admin/auth';
 
-if (!admin.apps.length) {
-    try {
-        // Check if we have individual env vars (as per .env.example)
-        if (process.env.FIREBASE_CLIENT_EMAIL && process.env.FIREBASE_PRIVATE_KEY) {
-            admin.initializeApp({
-                credential: admin.credential.cert({
-                    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-                    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-                    privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
-                }),
-            });
-        }
-        // Fallback: Use Application Default Credentials (ADC)
-        // This works if `gcloud auth application-default login` has been run locally
-        else {
-            console.log('Firebase Admin SDK: Using Application Default Credentials.');
-            admin.initializeApp({
-                credential: admin.credential.applicationDefault(),
-                projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-            });
-        }
-    } catch (error) {
-        console.error('Firebase Admin SDK initialization failed:', error);
-    }
+// If GOOGLE_APPLICATION_CREDENTIALS points to a file that doesn't exist (e.g.
+// the local key path from .env.local leaked into the deployed backend), drop it
+// so Application Default Credentials fall back to the GCP runtime service
+// account instead of failing with ENOENT.
+const gac = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (gac && !existsSync(gac)) {
+  delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
 }
 
+// Use a DEDICATED NAMED app rather than the default app slot: the Firebase
+// web-frameworks Cloud Run runtime pre-registers its own (non-[DEFAULT]) admin
+// app, so any default-app lookup throws `app/no-app`. A named app we own can't
+// collide with it.
+const ADMIN_APP_NAME = 'nlr-admin';
+
+function getAdminApp(): App {
+  const existing = getApps().find((a) => a?.name === ADMIN_APP_NAME);
+  if (existing) return existing;
+
+  if (process.env.FIREBASE_CLIENT_EMAIL && process.env.FIREBASE_PRIVATE_KEY) {
+    return initializeApp(
+      {
+        credential: cert({
+          projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+          clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+          privateKey: (process.env.FIREBASE_PRIVATE_KEY as string).replace(/\\n/g, '\n'),
+        }),
+      },
+      ADMIN_APP_NAME
+    );
+  }
+
+  // ADC: GOOGLE_APPLICATION_CREDENTIALS locally (see .env.local) or the GCP
+  // runtime service account when deployed.
+  const projectId =
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ||
+    process.env.GOOGLE_CLOUD_PROJECT ||
+    process.env.GCLOUD_PROJECT;
+
+  return initializeApp({ credential: applicationDefault(), projectId }, ADMIN_APP_NAME);
+}
+
+const app = getAdminApp();
+
 export const firebaseAdmin = admin;
-export const adminDb = admin.firestore(); // Renamed to avoid confusion with client-side 'db'
-export const adminAuth = admin.auth();
+export const adminDb = getFirestore(app);
+export const adminAuth = getAuth(app);

--- a/lib/firebase-utils.ts
+++ b/lib/firebase-utils.ts
@@ -84,6 +84,11 @@ export interface Property {
   managementStartDate?: any; // Timestamp
   managementEndDate?: any; // Timestamp
   managementStatus?: 'active' | 'inactive' | 'pending';
+  // GoHighLevel custom-object sync metadata (present on GHL-sourced docs)
+  ghlObjectId?: string; // GHL custom-object record id
+  ghlObjectKey?: string; // GHL custom-object key, e.g. custom_objects.properties
+  source?: 'ghl' | 'manual'; // origin of this property record
+  lastSyncedAt?: string; // ISO timestamp of the last GHL sync
   createdAt: any;
   updatedAt: any;
 }

--- a/lib/ghl-properties.ts
+++ b/lib/ghl-properties.ts
@@ -1,0 +1,377 @@
+// GoHighLevel (LeadConnector) v2 Custom Objects client — "Properties".
+//
+// The contacts client in ./ghl.ts only knows about contacts. GHL stores
+// properties as a *custom object*, which lives on a different API surface
+// (`/objects/...`). This module discovers the Properties object, reads its
+// records, and maps each record onto the app's Firestore `Property` shape.
+//
+// Two things vary between GHL accounts and are handled defensively:
+//   1. The API version header. Contacts use 2021-07-28; some accounts require a
+//      newer value for Objects. Override via GHL_OBJECTS_API_VERSION if needed.
+//   2. The custom field keys/ids on the object. These are auto-detected by a
+//      name heuristic, and can be pinned exactly via GHL_PROP_FIELD_* env vars
+//      (run `npm run discover:ghl-properties` to see the real keys).
+
+import { ghlFetch, getCredentials, isGHLConfigured } from './ghl';
+
+export { isGHLConfigured };
+
+// Objects API version — overridable because some accounts require a newer value.
+const OBJECTS_API_VERSION = process.env.GHL_OBJECTS_API_VERSION || '2021-07-28';
+
+// The custom object key, e.g. "custom_objects.properties". Blank => auto-discover.
+export const GHL_PROPERTY_OBJECT_KEY = process.env.GHL_PROPERTY_OBJECT_KEY || '';
+
+// Field references. Each may be a GHL field id OR fieldKey. Blank values fall
+// back to a name heuristic in the mapper (see CANDIDATES below).
+export const GHL_PROPERTY_FIELD_IDS = {
+  NAME: process.env.GHL_PROP_FIELD_NAME || '',
+  ADDRESS: process.env.GHL_PROP_FIELD_ADDRESS || '',
+  DESCRIPTION: process.env.GHL_PROP_FIELD_DESCRIPTION || '',
+  RENT: process.env.GHL_PROP_FIELD_RENT || '',
+  BEDROOMS: process.env.GHL_PROP_FIELD_BEDROOMS || '',
+  BATHROOMS: process.env.GHL_PROP_FIELD_BATHROOMS || '',
+  SQUARE_FEET: process.env.GHL_PROP_FIELD_SQFT || '',
+  AVAILABLE: process.env.GHL_PROP_FIELD_AVAILABLE || '',
+  IMAGES: process.env.GHL_PROP_FIELD_IMAGES || '',
+  AMENITIES: process.env.GHL_PROP_FIELD_AMENITIES || '',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type GHLObjectSummary = {
+  id?: string;
+  key: string;
+  labels?: { singular?: string; plural?: string };
+};
+
+export type GHLObjectField = {
+  id?: string;
+  fieldKey?: string;
+  name?: string;
+  dataType?: string;
+};
+
+export type GHLObjectSchema = {
+  id?: string;
+  key: string;
+  labels?: { singular?: string; plural?: string };
+  fields: GHLObjectField[];
+};
+
+// A record normalized to a stable shape regardless of GHL's response variant.
+export type GHLPropertyField = { id?: string; fieldKey?: string; key?: string; name?: string; value: unknown };
+
+export type GHLPropertyRecord = {
+  id: string;
+  properties: Record<string, unknown> | GHLPropertyField[];
+  raw: any;
+};
+
+export type MappedProperty = {
+  ghlObjectId: string;
+  name: string;
+  address: string;
+  description: string;
+  rent: number;
+  bedrooms: number;
+  bathrooms: number;
+  squareFeet: number;
+  available: boolean;
+  images: string[];
+  amenities: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Low-level requests
+// ---------------------------------------------------------------------------
+
+function objectsFetch(path: string, init: { method?: string; body?: unknown } = {}) {
+  return ghlFetch(path, { ...init, version: OBJECTS_API_VERSION });
+}
+
+/** List every object (standard + custom) configured for the location. */
+export async function listGHLObjects(): Promise<GHLObjectSummary[]> {
+  const { locationId } = getCredentials();
+  const data = await objectsFetch(`/objects/?locationId=${encodeURIComponent(locationId || '')}`);
+  const objects = data.objects || data.customObjects || data.data || [];
+  return (objects as any[]).map((o) => ({
+    id: o.id,
+    key: o.key,
+    labels: o.labels,
+  }));
+}
+
+/** Fetch an object's schema (including its fields) by key. */
+export async function getGHLObjectSchema(key: string): Promise<GHLObjectSchema | null> {
+  const { locationId } = getCredentials();
+  try {
+    const data = await objectsFetch(
+      `/objects/${encodeURIComponent(key)}?locationId=${encodeURIComponent(locationId || '')}&fetchProperties=true`
+    );
+    const obj = data.object || data;
+    const fields = data.fields || obj.fields || obj.properties || [];
+    return { id: obj.id, key: obj.key || key, labels: obj.labels, fields };
+  } catch (err) {
+    console.error(`GHL getObjectSchema(${key}) failed:`, err);
+    return null;
+  }
+}
+
+/**
+ * Resolve the Properties custom-object key: explicit env override wins,
+ * otherwise find an object whose key/labels look like "propert…". Returns null
+ * if none can be found.
+ */
+export async function discoverPropertyObjectKey(): Promise<string | null> {
+  if (GHL_PROPERTY_OBJECT_KEY) return GHL_PROPERTY_OBJECT_KEY;
+  const objects = await listGHLObjects();
+  const looksLikeProperty = (s?: string) => !!s && /propert/i.test(s);
+  const match = objects.find(
+    (o) =>
+      looksLikeProperty(o.key) ||
+      looksLikeProperty(o.labels?.singular) ||
+      looksLikeProperty(o.labels?.plural)
+  );
+  return match?.key || null;
+}
+
+/** Like discoverPropertyObjectKey but throws a helpful error when not found. */
+export async function resolvePropertyObjectKey(): Promise<string> {
+  const key = await discoverPropertyObjectKey();
+  if (!key) {
+    throw new Error(
+      'Could not find a GHL "Properties" custom object. Set GHL_PROPERTY_OBJECT_KEY ' +
+        'in your environment, or run `npm run discover:ghl-properties` to list available objects.'
+    );
+  }
+  return key;
+}
+
+function normalizeRecord(raw: any): GHLPropertyRecord {
+  const rec = raw?.record ?? raw ?? {};
+  const id = rec.id ?? rec._id ?? rec.recordId ?? '';
+  const properties = rec.properties ?? rec.customFields ?? rec.data ?? rec.values ?? {};
+  return { id: String(id), properties, raw: rec };
+}
+
+/** Search a single page of property records. */
+export async function searchGHLPropertyRecords(opts: {
+  page?: number;
+  pageLimit?: number;
+  searchAfter?: unknown[];
+} = {}): Promise<{ records: GHLPropertyRecord[]; total: number; searchAfter?: unknown[] }> {
+  const { locationId } = getCredentials();
+  const key = await resolvePropertyObjectKey();
+  const body: Record<string, unknown> = {
+    locationId,
+    page: opts.page ?? 1,
+    pageLimit: opts.pageLimit ?? 100,
+  };
+  if (opts.searchAfter) body.searchAfter = opts.searchAfter;
+
+  const data = await objectsFetch(`/objects/${encodeURIComponent(key)}/records/search`, {
+    method: 'POST',
+    body,
+  });
+
+  const rawRecords = data.records || data.data || [];
+  const records = (rawRecords as any[]).map(normalizeRecord);
+  const total = data.total ?? data.pageInfo?.total ?? records.length;
+  const lastRaw = (rawRecords as any[])[rawRecords.length - 1];
+  const searchAfter = lastRaw?.searchAfter ?? data.pageInfo?.searchAfter;
+  return { records, total, searchAfter };
+}
+
+/** Fetch ALL property records, paginating with a small throttle. */
+export async function getAllGHLPropertyRecords(): Promise<GHLPropertyRecord[]> {
+  const pageLimit = 100;
+  const all: GHLPropertyRecord[] = [];
+  let page = 1;
+  let searchAfter: unknown[] | undefined;
+  const MAX_PAGES = 100; // safety backstop (~10k records)
+
+  while (page <= MAX_PAGES) {
+    const { records, total, searchAfter: next } = await searchGHLPropertyRecords({
+      page,
+      pageLimit,
+      searchAfter,
+    });
+    all.push(...records);
+
+    if (records.length < pageLimit) break;
+    if (total && all.length >= total) break;
+
+    searchAfter = next as unknown[] | undefined;
+    page += 1;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return all;
+}
+
+/** Fetch a single property record by id. */
+export async function getGHLPropertyRecord(id: string): Promise<GHLPropertyRecord | null> {
+  const { locationId } = getCredentials();
+  const key = await resolvePropertyObjectKey();
+  try {
+    const data = await objectsFetch(
+      `/objects/${encodeURIComponent(key)}/records/${encodeURIComponent(id)}?locationId=${encodeURIComponent(
+        locationId || ''
+      )}`
+    );
+    return normalizeRecord(data);
+  } catch (err) {
+    console.error(`GHL getPropertyRecord(${id}) failed:`, err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mapping: GHL record -> Firestore Property
+// ---------------------------------------------------------------------------
+
+// Fallback field-name candidates used when no explicit id/key is configured.
+const CANDIDATES = {
+  name: ['name', 'property_name', 'title', 'property_title'],
+  address: ['address', 'full_address', 'street_address', 'property_address', 'location'],
+  description: ['description', 'details', 'notes', 'about'],
+  rent: ['rent', 'monthly_rent', 'price', 'rent_amount', 'monthlyrent'],
+  bedrooms: ['bedrooms', 'beds', 'bedroom', 'num_bedrooms'],
+  bathrooms: ['bathrooms', 'baths', 'bathroom', 'num_bathrooms'],
+  squareFeet: ['square_feet', 'squarefeet', 'sqft', 'sq_ft', 'size', 'area'],
+  available: ['available', 'is_available', 'availability', 'vacant', 'status'],
+  images: ['images', 'image', 'photos', 'photo', 'image_url', 'image_urls'],
+  amenities: ['amenities', 'features', 'amenity'],
+} as const;
+
+/** Normalize a field key/name to bare alphanumerics (last dotted segment). */
+function normKey(k: string): string {
+  const last = k.includes('.') ? k.slice(k.lastIndexOf('.') + 1) : k;
+  return last.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+type Lookup = { byId: Record<string, unknown>; byKey: Record<string, unknown> };
+
+function buildLookup(properties: GHLPropertyRecord['properties']): Lookup {
+  const byId: Record<string, unknown> = {};
+  const byKey: Record<string, unknown> = {};
+  if (Array.isArray(properties)) {
+    for (const f of properties) {
+      if (!f) continue;
+      if (f.id != null) byId[String(f.id)] = f.value;
+      const k = f.fieldKey ?? f.key ?? f.name;
+      if (k != null) byKey[normKey(String(k))] = f.value;
+    }
+  } else if (properties && typeof properties === 'object') {
+    for (const [k, v] of Object.entries(properties)) {
+      byId[k] = v; // a flat object's keys may already be field ids
+      byKey[normKey(k)] = v;
+    }
+  }
+  return { byId, byKey };
+}
+
+function pickVal(lookup: Lookup, configuredRef: string, candidates: readonly string[]): unknown {
+  // 1. Explicit configuration (treat as either a field id or a field key).
+  if (configuredRef) {
+    if (lookup.byId[configuredRef] !== undefined) return lookup.byId[configuredRef];
+    const nk = normKey(configuredRef);
+    if (lookup.byKey[nk] !== undefined) return lookup.byKey[nk];
+  }
+  // 2. Exact normalized candidate match.
+  for (const c of candidates) {
+    const v = lookup.byKey[normKey(c)];
+    if (v !== undefined) return v;
+  }
+  // 3. Loose "contains" match as a last resort.
+  const keys = Object.keys(lookup.byKey);
+  for (const c of candidates) {
+    const nc = normKey(c);
+    const hit = keys.find((k) => k === nc || k.includes(nc));
+    if (hit && lookup.byKey[hit] !== undefined) return lookup.byKey[hit];
+  }
+  return undefined;
+}
+
+function toStr(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'string') return v.trim();
+  if (Array.isArray(v)) return v.map(toStr).filter(Boolean).join(', ');
+  return String(v);
+}
+
+function toNum(v: unknown): number {
+  if (v == null) return 0;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : 0;
+  if (typeof v === 'string') {
+    const n = parseFloat(v.replace(/[^0-9.\-]/g, ''));
+    return Number.isFinite(n) ? n : 0;
+  }
+  // GHL MONETORY/currency fields arrive as { currency, value }.
+  if (typeof v === 'object') {
+    const inner = (v as any).value ?? (v as any).amount;
+    return inner != null ? toNum(inner) : 0;
+  }
+  return 0;
+}
+
+function toArr(v: unknown): string[] {
+  if (v == null) return [];
+  if (Array.isArray(v)) {
+    return v
+      .map((item) =>
+        item && typeof item === 'object'
+          ? toStr((item as any).url ?? (item as any).value ?? (item as any).name)
+          : toStr(item)
+      )
+      .filter(Boolean);
+  }
+  if (typeof v === 'string') {
+    return v
+      .split(/[\n,]/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+/** Coerce an "available" value; defaults to true when the field is absent. */
+function toAvailable(v: unknown): boolean {
+  if (v == null) return true; // default per spec
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'number') return v !== 0;
+  if (Array.isArray(v)) return v.length > 0;
+  const s = String(v).toLowerCase().trim();
+  if (['occupied', 'rented', 'unavailable', 'no', 'false', '0', 'inactive', 'leased'].includes(s)) {
+    return false;
+  }
+  if (['available', 'vacant', 'yes', 'true', '1', 'active', 'for rent', 'for_rent', 'open'].includes(s)) {
+    return true;
+  }
+  return true; // unknown string -> default available
+}
+
+/** Pure, testable mapping from a GHL record to the app's Property fields. */
+export function mapGHLRecordToProperty(record: GHLPropertyRecord): MappedProperty {
+  const lookup = buildLookup(record.properties);
+  const F = GHL_PROPERTY_FIELD_IDS;
+
+  const name = toStr(pickVal(lookup, F.NAME, CANDIDATES.name));
+  const address = toStr(pickVal(lookup, F.ADDRESS, CANDIDATES.address));
+
+  return {
+    ghlObjectId: record.id,
+    name,
+    address,
+    description: toStr(pickVal(lookup, F.DESCRIPTION, CANDIDATES.description)),
+    rent: toNum(pickVal(lookup, F.RENT, CANDIDATES.rent)),
+    bedrooms: toNum(pickVal(lookup, F.BEDROOMS, CANDIDATES.bedrooms)),
+    bathrooms: toNum(pickVal(lookup, F.BATHROOMS, CANDIDATES.bathrooms)),
+    squareFeet: toNum(pickVal(lookup, F.SQUARE_FEET, CANDIDATES.squareFeet)),
+    available: toAvailable(pickVal(lookup, F.AVAILABLE, CANDIDATES.available)),
+    images: toArr(pickVal(lookup, F.IMAGES, CANDIDATES.images)),
+    amenities: toArr(pickVal(lookup, F.AMENITIES, CANDIDATES.amenities)),
+  };
+}

--- a/lib/ghl-sync.ts
+++ b/lib/ghl-sync.ts
@@ -16,6 +16,12 @@ import {
   addGHLContactNote,
   addGHLContactTags,
 } from './ghl';
+import {
+  GHL_PROPERTY_OBJECT_KEY,
+  getAllGHLPropertyRecords,
+  mapGHLRecordToProperty,
+  resolvePropertyObjectKey,
+} from './ghl-properties';
 
 /**
  * Run a GHL side-effect without letting failures bubble up to the caller.
@@ -228,5 +234,106 @@ export async function pushMaintenanceStatusToGHL(params: {
   });
 }
 
-// Re-export for callers that want the custom field ids.
-export { GHL_FIELD_IDS };
+// ---------------------------------------------------------------------------
+// Pull: GHL Properties custom object -> Firestore `properties`
+// ---------------------------------------------------------------------------
+
+export type PropertySyncResult = {
+  total: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: { recordId: string; message: string }[];
+  objectKey: string;
+};
+
+/**
+ * Pull all "Properties" custom-object records from GHL into Firestore.
+ *
+ * Each record is upserted to `properties/ghl-{recordId}` (deterministic id =>
+ * idempotent re-runs, no duplicates) and tagged with `source: 'ghl'`. Existing
+ * manually-created property docs (random ids) are left untouched so existing
+ * maintenance/ledger/tenant joins keep working. GHL is the source of truth, so
+ * a record missing both a name and an address is skipped.
+ */
+export async function syncGHLPropertiesToFirestore(
+  opts: { dryRun?: boolean } = {}
+): Promise<PropertySyncResult> {
+  const result: PropertySyncResult = {
+    total: 0,
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    errors: [],
+    objectKey: '',
+  };
+
+  if (!isGHLConfigured()) {
+    result.errors.push({ recordId: '-', message: 'GoHighLevel is not configured' });
+    return result;
+  }
+
+  const objectKey = await resolvePropertyObjectKey();
+  result.objectKey = objectKey;
+
+  const records = await getAllGHLPropertyRecords();
+  result.total = records.length;
+
+  for (const record of records) {
+    try {
+      const mapped = mapGHLRecordToProperty(record);
+
+      // GHL is authoritative; an empty record (no name AND no address) is noise.
+      if (!mapped.name && !mapped.address) {
+        result.skipped++;
+        continue;
+      }
+
+      const ref = adminDb.collection('properties').doc(`ghl-${record.id}`);
+      const existing = await ref.get();
+
+      const data: Record<string, unknown> = {
+        name: mapped.name || mapped.address,
+        address: mapped.address,
+        description: mapped.description,
+        rent: mapped.rent,
+        bedrooms: mapped.bedrooms,
+        bathrooms: mapped.bathrooms,
+        squareFeet: mapped.squareFeet,
+        available: mapped.available,
+        amenities: mapped.amenities,
+        ghlObjectId: mapped.ghlObjectId,
+        ghlObjectKey: objectKey,
+        source: 'ghl',
+        lastSyncedAt: new Date().toISOString(),
+        updatedAt: FieldValue.serverTimestamp(),
+        // Set createdAt only on first write so admin `orderBy createdAt` works.
+        ...(existing.exists ? {} : { createdAt: FieldValue.serverTimestamp() }),
+      };
+
+      // Only overwrite images when GHL actually returned some; seed [] on create.
+      if (mapped.images.length) {
+        data.images = mapped.images;
+      } else if (!existing.exists) {
+        data.images = [];
+      }
+
+      if (!opts.dryRun) {
+        await ref.set(data, { merge: true });
+      }
+
+      if (existing.exists) result.updated++;
+      else result.created++;
+
+      // Throttle Firestore writes / stay friendly to GHL rate limits.
+      await new Promise((r) => setTimeout(r, 200));
+    } catch (err: any) {
+      result.errors.push({ recordId: record.id || '-', message: err?.message || String(err) });
+    }
+  }
+
+  return result;
+}
+
+// Re-export for callers that want the custom field ids / object key.
+export { GHL_FIELD_IDS, GHL_PROPERTY_OBJECT_KEY };

--- a/lib/ghl-sync.ts
+++ b/lib/ghl-sync.ts
@@ -15,6 +15,7 @@ import {
   upsertGHLContact,
   addGHLContactNote,
   addGHLContactTags,
+  searchGHLContactsByTag,
 } from './ghl';
 import {
   GHL_PROPERTY_OBJECT_KEY,
@@ -329,6 +330,150 @@ export async function syncGHLPropertiesToFirestore(
       await new Promise((r) => setTimeout(r, 200));
     } catch (err: any) {
       result.errors.push({ recordId: record.id || '-', message: err?.message || String(err) });
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Import: GHL active-tenant contacts -> Firestore `users` (role: tenant)
+// ---------------------------------------------------------------------------
+
+export type TenantImportResult = {
+  total: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  matched: number; // tenants linked to a property by address
+  unmatched: number; // tenants with an address but no property match
+  errors: { contactId: string; message: string }[];
+};
+
+/** Normalize an address for loose comparison (lowercase, alphanumerics + spaces). */
+function normalizeAddress(s?: string | null): string {
+  return (s || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Import active tenants from GHL (contacts carrying `tag`, default "active")
+ * into the Firestore `users` collection as role 'tenant'. Records only — no
+ * Firebase Auth accounts are created. De-duplicates by email (updates the
+ * existing user doc when present, else creates `users/ghl-{contactId}`), never
+ * demotes an admin, and best-effort links each tenant to a property by address.
+ */
+export async function importActiveTenantsFromGHL(
+  opts: { tag?: string; dryRun?: boolean } = {}
+): Promise<TenantImportResult> {
+  const tag = opts.tag || 'active';
+  const result: TenantImportResult = {
+    total: 0,
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    matched: 0,
+    unmatched: 0,
+    errors: [],
+  };
+
+  if (!isGHLConfigured()) {
+    result.errors.push({ contactId: '-', message: 'GoHighLevel is not configured' });
+    return result;
+  }
+
+  const contacts = await searchGHLContactsByTag(tag);
+  result.total = contacts.length;
+
+  // Index property addresses once for best-effort tenant->property matching.
+  const propsSnap = await adminDb.collection('properties').get();
+  const propIndex = propsSnap.docs
+    .map((d) => ({
+      id: d.id,
+      name: (d.data().name as string) || '',
+      addr: normalizeAddress(d.data().address as string),
+    }))
+    .filter((p) => p.addr);
+
+  for (const c of contacts) {
+    try {
+      if (!c.email) {
+        result.skipped++;
+        continue;
+      }
+
+      // De-dup by email.
+      const existingSnap = await adminDb
+        .collection('users')
+        .where('email', '==', c.email)
+        .limit(1)
+        .get();
+      const isUpdate = !existingSnap.empty;
+      const existingData = isUpdate ? existingSnap.docs[0].data() : null;
+
+      // Never modify an admin who happens to carry the tag.
+      if (existingData && (existingData.role === 'admin' || existingData.role === 'super-admin')) {
+        result.skipped++;
+        continue;
+      }
+
+      const ref = isUpdate
+        ? existingSnap.docs[0].ref
+        : adminDb.collection('users').doc(`ghl-${c.id}`);
+
+      // Best-effort address match to a property.
+      const tenantAddr = normalizeAddress(c.address);
+      let matched: { id: string; name: string } | undefined;
+      if (tenantAddr && tenantAddr.length >= 5) {
+        const hit = propIndex.find(
+          (p) => p.addr === tenantAddr || p.addr.startsWith(tenantAddr) || tenantAddr.startsWith(p.addr)
+        );
+        if (hit) matched = { id: hit.id, name: hit.name };
+        if (matched) result.matched++;
+        else result.unmatched++;
+      }
+
+      const displayName =
+        c.name || [c.firstName, c.lastName].filter(Boolean).join(' ') || c.email;
+
+      const data: Record<string, unknown> = {
+        email: c.email,
+        displayName,
+        role: 'tenant',
+        ghlContactId: c.id,
+        phoneNumber: c.phone ?? null,
+        address: c.address ?? null,
+        city: c.city ?? null,
+        state: c.state ?? null,
+        zip: c.postalCode ?? null,
+        monthlyRent: c.monthlyRent ?? null,
+        leaseStart: c.leaseStart ?? null,
+        leaseEnd: c.leaseEnd ?? null,
+        isLeaseActive: Boolean(c.isLeaseActive),
+        source: 'ghl',
+        lastSyncedAt: new Date().toISOString(),
+      };
+
+      // Link to a property only if matched and we won't clobber a manual assignment.
+      if (matched && !(existingData?.propertyIds?.length)) {
+        data.propertyIds = [matched.id];
+        data.unit = existingData?.unit || matched.name;
+      }
+      if (!isUpdate) data.createdAt = new Date().toISOString();
+
+      if (!opts.dryRun) {
+        await ref.set(data, { merge: true });
+      }
+
+      if (isUpdate) result.updated++;
+      else result.created++;
+
+      await new Promise((r) => setTimeout(r, 100));
+    } catch (err: any) {
+      result.errors.push({ contactId: c.id || '-', message: err?.message || String(err) });
     }
   }
 

--- a/lib/ghl.ts
+++ b/lib/ghl.ts
@@ -10,8 +10,8 @@
 //   GHL_API_KEY      (preferred)  or  GHL_ACCESS_TOKEN
 //   GHL_LOCATION_ID  (preferred)  or  LOCATION_ID
 
-const GHL_API_BASE = 'https://services.leadconnectorhq.com';
-const GHL_API_VERSION = '2021-07-28';
+export const GHL_API_BASE = 'https://services.leadconnectorhq.com';
+export const GHL_API_VERSION = '2021-07-28';
 
 // Custom Field IDs (from the GHL location's contact custom fields).
 export const GHL_FIELD_IDS = {
@@ -54,7 +54,7 @@ export type UpsertContactInput = {
   customFields?: GHLCustomField[];
 };
 
-function getCredentials(): { token: string; locationId: string | undefined } {
+export function getCredentials(): { token: string; locationId: string | undefined } {
   const token = process.env.GHL_API_KEY || process.env.GHL_ACCESS_TOKEN;
   const locationId = process.env.GHL_LOCATION_ID || process.env.LOCATION_ID;
   if (!token) {
@@ -70,16 +70,16 @@ export function isGHLConfigured(): boolean {
   return Boolean(process.env.GHL_API_KEY || process.env.GHL_ACCESS_TOKEN);
 }
 
-async function ghlFetch(
+export async function ghlFetch(
   path: string,
-  init: { method?: string; body?: unknown } = {}
+  init: { method?: string; body?: unknown; version?: string } = {}
 ): Promise<any> {
   const { token } = getCredentials();
   const res = await fetch(`${GHL_API_BASE}${path}`, {
     method: init.method || 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
-      Version: GHL_API_VERSION,
+      Version: init.version || GHL_API_VERSION,
       'Content-Type': 'application/json',
       Accept: 'application/json',
     },

--- a/lib/ghl.ts
+++ b/lib/ghl.ts
@@ -26,6 +26,7 @@ export type GHLCustomField = { id: string; value: unknown };
 export type GHLContact = {
   id: string;
   email: string;
+  name?: string;
   firstName?: string;
   lastName?: string;
   phone?: string;
@@ -114,6 +115,7 @@ function parseGHLContact(raw: any): GHLContact {
   return {
     id: raw.id,
     email: raw.email,
+    name: raw.contactName || [raw.firstName, raw.lastName].filter(Boolean).join(' ') || undefined,
     firstName: raw.firstName,
     lastName: raw.lastName,
     phone: raw.phone,
@@ -153,6 +155,43 @@ export async function getGHLContactById(contactId: string): Promise<GHLContact |
     console.error(`GHL getContactById(${contactId}) failed:`, err);
     return null;
   }
+}
+
+/**
+ * Search all contacts carrying a given tag (e.g. "active"), paginating through
+ * the v2 search API. Used to import an "active tenants" smart-list equivalent.
+ */
+export async function searchGHLContactsByTag(tag: string): Promise<GHLContact[]> {
+  const { locationId } = getCredentials();
+  const pageLimit = 100;
+  const MAX_PAGES = 50; // safety backstop (~5k contacts)
+  const all: GHLContact[] = [];
+  let page = 1;
+
+  while (page <= MAX_PAGES) {
+    const data = await ghlFetch('/contacts/search', {
+      method: 'POST',
+      body: {
+        locationId,
+        page,
+        pageLimit,
+        filters: [{ field: 'tags', operator: 'contains', value: tag }],
+      },
+    });
+
+    const contacts: any[] = data.contacts || [];
+    all.push(...contacts.map(parseGHLContact));
+
+    const total = data.total ?? all.length;
+    if (contacts.length < pageLimit) break;
+    if (total && all.length >= total) break;
+
+    page += 1;
+    // CARIV throttles ~11 rapid calls -> space requests out.
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  return all;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/properties-public.ts
+++ b/lib/properties-public.ts
@@ -1,0 +1,42 @@
+// Server-only helper for exposing available properties to unauthenticated
+// visitors (the public landing page). Reads via the Admin SDK so it bypasses
+// the authenticated-only `properties` Firestore rule WITHOUT loosening it, and
+// returns an explicit, public-safe field whitelist (no landlord / management
+// data ever leaves the server).
+
+import { adminDb } from './firebase-admin';
+
+export type PublicProperty = {
+  id: string;
+  name: string;
+  address: string;
+  description: string;
+  images: string[];
+  bedrooms: number;
+  bathrooms: number;
+  squareFeet: number;
+  rent: number;
+};
+
+export async function getPublicProperties(): Promise<PublicProperty[]> {
+  const snap = await adminDb.collection('properties').where('available', '==', true).get();
+
+  const list: PublicProperty[] = snap.docs.map((doc) => {
+    const p = doc.data();
+    return {
+      id: doc.id,
+      name: (p.name as string) || (p.address as string) || 'Property',
+      address: (p.address as string) || '',
+      description: (p.description as string) || '',
+      images: Array.isArray(p.images) ? (p.images as string[]) : [],
+      bedrooms: Number(p.bedrooms) || 0,
+      bathrooms: Number(p.bathrooms) || 0,
+      squareFeet: Number(p.squareFeet) || 0,
+      rent: Number(p.rent) || 0,
+    };
+  });
+
+  // Sort in JS (cheapest rent first) to avoid requiring a composite index.
+  list.sort((a, b) => a.rent - b.rent);
+  return list;
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "seed:roles": "node scripts/seed-roles.js",
     "discover:ghl-properties": "node scripts/discover-ghl-properties.js",
     "sync:ghl-properties": "node scripts/sync-ghl-properties.js",
+    "import:active-tenants": "node scripts/import-active-tenants.js",
     "deploy": "npm run build && firebase deploy",
     "deploy:hosting": "npm run build && firebase deploy --only hosting",
     "deploy:rules": "firebase deploy --only firestore:rules,storage",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "start": "next start",
     "lint": "next lint",
     "seed:roles": "node scripts/seed-roles.js",
+    "discover:ghl-properties": "node scripts/discover-ghl-properties.js",
+    "sync:ghl-properties": "node scripts/sync-ghl-properties.js",
     "deploy": "npm run build && firebase deploy",
     "deploy:hosting": "npm run build && firebase deploy --only hosting",
     "deploy:rules": "firebase deploy --only firestore:rules,storage",

--- a/pages/admin/properties.tsx
+++ b/pages/admin/properties.tsx
@@ -6,13 +6,22 @@ import SiteLayout from '@/components/Layout/SiteLayout';
 import AddPropertyModal from '@/components/Admin/AddPropertyModal';
 import { propertyUtils } from '@/lib/firebase-utils';
 import type { Property } from '@/lib/firebase-utils';
+import { useAuth } from '@/context/AuthContext';
 import type { NextPageWithAuth } from '../_app';
+
+// Properties are sourced from GoHighLevel and synced into Firestore, so the app
+// is read-only for them. Flip to true (and set ALLOW_MANUAL_PROPERTY=true on the
+// server) to temporarily re-enable in-app creation.
+const ALLOW_MANUAL_PROPERTY = false;
 
 const PropertiesPage: NextPageWithAuth = () => {
   const router = useRouter();
+  const { user } = useAuth();
   const [properties, setProperties] = useState<Property[]>([]);
   const [loading, setLoading] = useState(true);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
 
   const fetchProperties = async () => {
     try {
@@ -32,6 +41,31 @@ const PropertiesPage: NextPageWithAuth = () => {
 
   const handleAddProperty = () => {
     setIsAddModalOpen(true);
+  };
+
+  const handleSyncFromGHL = async () => {
+    if (!user) return;
+    setSyncing(true);
+    setSyncMessage(null);
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch('/api/admin/sync-properties', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({}),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Sync failed');
+      setSyncMessage(data.message);
+      await fetchProperties();
+    } catch (err: any) {
+      setSyncMessage(err.message || 'Sync failed');
+    } finally {
+      setSyncing(false);
+    }
   };
 
   const handlePropertyCreated = () => {
@@ -56,10 +90,19 @@ const PropertiesPage: NextPageWithAuth = () => {
         <header className="admin-header">
           <div>
             <h1>Properties</h1>
-            <p>Overview of all physical units and their current status.</p>
+            <p>Synced from GoHighLevel. Overview of all units and their current status.</p>
           </div>
-          <button className="primary-button" onClick={handleAddProperty}>+ Add Property</button>
+          <div className="header-actions">
+            <button className="primary-button" onClick={handleSyncFromGHL} disabled={syncing}>
+              {syncing ? 'Syncing…' : 'Sync from GHL'}
+            </button>
+            {ALLOW_MANUAL_PROPERTY && (
+              <button className="secondary-button" onClick={handleAddProperty}>+ Add Property</button>
+            )}
+          </div>
         </header>
+
+        {syncMessage && <div className="sync-banner">{syncMessage}</div>}
 
         {loading ? (
           <div className="loading-state">Loading properties...</div>
@@ -84,6 +127,7 @@ const PropertiesPage: NextPageWithAuth = () => {
                 </div>
                 <div className="property-content">
                   <h3>{property.name}</h3>
+                  {property.source === 'ghl' && <span className="ghl-badge">Synced from GHL</span>}
                   <p className="address">{property.address}</p>
                   <div className="property-details">
                     <span>{property.bedrooms} Bed</span>
@@ -101,11 +145,13 @@ const PropertiesPage: NextPageWithAuth = () => {
         )}
       </div>
 
-      <AddPropertyModal
-        isOpen={isAddModalOpen}
-        onClose={() => setIsAddModalOpen(false)}
-        onSuccess={handlePropertyCreated}
-      />
+      {ALLOW_MANUAL_PROPERTY && (
+        <AddPropertyModal
+          isOpen={isAddModalOpen}
+          onClose={() => setIsAddModalOpen(false)}
+          onSuccess={handlePropertyCreated}
+        />
+      )}
 
       <style jsx>{`
         .admin-container {
@@ -119,6 +165,35 @@ const PropertiesPage: NextPageWithAuth = () => {
           justify-content: space-between;
           align-items: center;
           margin-bottom: 2rem;
+        }
+
+        .header-actions {
+          display: flex;
+          gap: 0.75rem;
+          align-items: center;
+        }
+
+        .sync-banner {
+          background: var(--color-surface-elevated);
+          border: 1px solid var(--color-border);
+          border-left: 4px solid var(--color-primary);
+          border-radius: var(--radius-md);
+          padding: 0.75rem 1rem;
+          margin-bottom: 1.5rem;
+          color: var(--color-text-secondary);
+          font-size: 0.9rem;
+        }
+
+        .ghl-badge {
+          display: inline-block;
+          margin: 0.25rem 0;
+          padding: 0.15rem 0.6rem;
+          border-radius: 9999px;
+          font-size: 0.7rem;
+          font-weight: 600;
+          letter-spacing: 0.03em;
+          background: rgba(15, 118, 110, 0.12);
+          color: var(--color-primary);
         }
 
         h1 { font-size: 2rem; color: var(--color-text-secondary); margin: 0; }

--- a/pages/admin/tenants.tsx
+++ b/pages/admin/tenants.tsx
@@ -12,6 +12,7 @@ const TenantsPage: NextPageWithAuth = () => {
     const [loading, setLoading] = useState(true);
     const [syncing, setSyncing] = useState<string | null>(null); // 'all' or a tenant id
     const [syncMessage, setSyncMessage] = useState<string | null>(null);
+    const [importing, setImporting] = useState(false);
 
     const fetchTenants = async () => {
         try {
@@ -27,6 +28,33 @@ const TenantsPage: NextPageWithAuth = () => {
     useEffect(() => {
         fetchTenants();
     }, []);
+
+    // Import active tenants (contacts tagged "active") from GoHighLevel as new
+    // tenant records. De-duplicates by email; best-effort links to a property.
+    const handleImport = async () => {
+        if (!user) return;
+        setImporting(true);
+        setSyncMessage(null);
+        try {
+            const token = await user.getIdToken();
+            const res = await fetch('/api/admin/import-tenants', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({ tag: 'active' }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.message || 'Import failed');
+            setSyncMessage(data.message || 'Import complete');
+            await fetchTenants();
+        } catch (err: any) {
+            setSyncMessage(err.message || 'Import failed');
+        } finally {
+            setImporting(false);
+        }
+    };
 
     // Pull tenant data from GoHighLevel. Pass a uid to sync one, omit for all.
     const handleSync = async (uid?: string) => {
@@ -69,9 +97,16 @@ const TenantsPage: NextPageWithAuth = () => {
                     <div className="header-actions">
                         {syncMessage && <span className="sync-message">{syncMessage}</span>}
                         <button
+                            className="sync-button sync-button--secondary"
+                            onClick={handleImport}
+                            disabled={importing || syncing !== null}
+                        >
+                            {importing ? 'Importing…' : 'Import active from GHL'}
+                        </button>
+                        <button
                             className="sync-button"
                             onClick={() => handleSync()}
-                            disabled={syncing !== null}
+                            disabled={importing || syncing !== null}
                         >
                             {syncing === 'all' ? 'Syncing…' : 'Sync all from GHL'}
                         </button>
@@ -190,6 +225,12 @@ const TenantsPage: NextPageWithAuth = () => {
         .sync-button:disabled {
           opacity: 0.6;
           cursor: not-allowed;
+        }
+
+        .sync-button--secondary {
+          background-color: transparent;
+          color: var(--color-primary);
+          border: 1px solid var(--color-primary);
         }
 
         .sync-link {

--- a/pages/api/admin/create-property.ts
+++ b/pages/api/admin/create-property.ts
@@ -23,6 +23,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
+  // Properties are sourced from GoHighLevel and synced in; manual creation is
+  // disabled by default. Set ALLOW_MANUAL_PROPERTY=true to re-enable.
+  if (process.env.ALLOW_MANUAL_PROPERTY !== 'true') {
+    return res.status(403).json({
+      message: 'Manual property creation is disabled; properties sync from GoHighLevel.',
+    });
+  }
+
   try {
     // 1. Verify auth token
     const authHeader = req.headers.authorization;

--- a/pages/api/admin/import-tenants.ts
+++ b/pages/api/admin/import-tenants.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { adminAuth, adminDb } from '@/lib/firebase-admin';
+import { importActiveTenantsFromGHL } from '@/lib/ghl-sync';
+import { isGHLConfigured } from '@/lib/ghl';
+
+// Admin endpoint to import active tenants from GoHighLevel (contacts carrying a
+// tag, default "active") into the Firestore `users` collection as role tenant.
+// Body: { tag?: string; dryRun?: boolean }. Records only — no auth accounts.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  if (!isGHLConfigured()) {
+    return res.status(503).json({ message: 'GoHighLevel is not configured' });
+  }
+
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
+      return res.status(401).json({ message: 'Unauthorized: Missing token' });
+    }
+
+    const decoded = await adminAuth.verifyIdToken(authHeader.split('Bearer ')[1]);
+    const callerRole = (await adminDb.collection('users').doc(decoded.uid).get()).data()?.role;
+    if (callerRole !== 'admin' && callerRole !== 'super-admin') {
+      return res.status(403).json({ message: 'Forbidden: Admin access required' });
+    }
+
+    const { tag, dryRun } = (req.body || {}) as { tag?: string; dryRun?: boolean };
+
+    const result = await importActiveTenantsFromGHL({ tag, dryRun: Boolean(dryRun) });
+
+    const verb = dryRun ? 'Previewed' : 'Imported';
+    return res.status(200).json({
+      message:
+        `${verb} ${result.total} '${tag || 'active'}' tenant(s): ` +
+        `${result.created} new, ${result.updated} updated, ${result.skipped} skipped` +
+        ` · ${result.matched} linked to a property, ${result.unmatched} unmatched` +
+        (result.errors.length ? ` · ${result.errors.length} error(s)` : ''),
+      ...result,
+    });
+  } catch (error: any) {
+    console.error('Admin tenant import error:', error);
+    return res.status(500).json({ message: error.message || 'Internal Server Error' });
+  }
+}

--- a/pages/api/admin/sync-properties.ts
+++ b/pages/api/admin/sync-properties.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { adminAuth, adminDb } from '@/lib/firebase-admin';
+import { syncGHLPropertiesToFirestore } from '@/lib/ghl-sync';
+import { isGHLConfigured } from '@/lib/ghl';
+
+// Admin endpoint to pull "Properties" custom-object records from GoHighLevel
+// into the Firestore `properties` collection. Body: { dryRun?: boolean } to
+// preview counts without writing. Returns a created/updated/skipped summary.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  if (!isGHLConfigured()) {
+    return res.status(503).json({ message: 'GoHighLevel is not configured' });
+  }
+
+  try {
+    // Verify caller is an admin.
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
+      return res.status(401).json({ message: 'Unauthorized: Missing token' });
+    }
+
+    const decoded = await adminAuth.verifyIdToken(authHeader.split('Bearer ')[1]);
+    const callerRole = (await adminDb.collection('users').doc(decoded.uid).get()).data()?.role;
+    if (callerRole !== 'admin' && callerRole !== 'super-admin') {
+      return res.status(403).json({ message: 'Forbidden: Admin access required' });
+    }
+
+    const { dryRun } = (req.body || {}) as { dryRun?: boolean };
+
+    const result = await syncGHLPropertiesToFirestore({ dryRun: Boolean(dryRun) });
+
+    const verb = dryRun ? 'Previewed' : 'Synced';
+    return res.status(200).json({
+      message: `${verb} ${result.total} GHL propert${result.total === 1 ? 'y' : 'ies'}: ` +
+        `${result.created} new, ${result.updated} updated, ${result.skipped} skipped` +
+        (result.errors.length ? `, ${result.errors.length} error(s)` : ''),
+      ...result,
+    });
+  } catch (error: any) {
+    console.error('Admin GHL property sync error:', error);
+    return res.status(500).json({ message: error.message || 'Internal Server Error' });
+  }
+}

--- a/pages/api/properties/public.ts
+++ b/pages/api/properties/public.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getPublicProperties } from '@/lib/properties-public';
+
+// Public, unauthenticated listing of available properties for the landing page.
+// Backed by the Admin SDK (server-side), returning only public-safe fields.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  try {
+    const properties = await getPublicProperties();
+    res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');
+    return res.status(200).json({ properties });
+  } catch (error: any) {
+    console.error('Public properties error:', error);
+    return res.status(500).json({ properties: [], message: 'Failed to load properties' });
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import SiteLayout from '@/components/Layout/SiteLayout';
 import TenantHero from '@/components/Landing/TenantHero';
 import CityEventsSection from '@/components/Landing/CityEventsSection';
@@ -6,8 +7,14 @@ import WeatherAlertsSection from '@/components/Landing/WeatherAlertsSection';
 import MaintenanceScheduleSection from '@/components/Landing/MaintenanceScheduleSection';
 import TenantResourcesSection from '@/components/Landing/TenantResourcesSection';
 import TenantCTASection from '@/components/Landing/TenantCTASection';
+import FeaturedPropertiesSection from '@/components/Landing/FeaturedPropertiesSection';
+import type { LandingProperty } from '@/components/Landing/FeaturedPropertiesSection';
 
-export default function HomePage() {
+type HomePageProps = {
+  properties: LandingProperty[];
+};
+
+export default function HomePage({ properties }: HomePageProps) {
   return (
     <SiteLayout>
       <Head>
@@ -19,6 +26,7 @@ export default function HomePage() {
       </Head>
       <main>
         <TenantHero />
+        <FeaturedPropertiesSection properties={properties} />
         <CityEventsSection />
         <WeatherAlertsSection />
         <MaintenanceScheduleSection />
@@ -28,3 +36,17 @@ export default function HomePage() {
     </SiteLayout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<HomePageProps> = async () => {
+  // Fetch available properties server-side via the Admin SDK. If GHL hasn't been
+  // synced or admin credentials are missing, fall back to an empty list so the
+  // landing page still renders (the section hides itself when empty).
+  let properties: LandingProperty[] = [];
+  try {
+    const { getPublicProperties } = await import('@/lib/properties-public');
+    properties = await getPublicProperties();
+  } catch (error) {
+    console.error('Landing properties fetch failed:', error);
+  }
+  return { props: { properties } };
+};

--- a/scripts/discover-ghl-properties.js
+++ b/scripts/discover-ghl-properties.js
@@ -1,0 +1,134 @@
+// Read-only discovery for the GoHighLevel "Properties" custom object.
+//
+// Lists the location's custom objects, prints the Properties schema (field
+// ids/keys/types) and one sample record, and emits a ready-to-paste env block.
+// It also resolves which API "Version" header your account accepts.
+//
+// Usage:
+//   GHL_API_KEY=pit-xxx GHL_LOCATION_ID=loc-xxx node scripts/discover-ghl-properties.js
+//   (or `npm run discover:ghl-properties` with those vars in your environment)
+
+require('./load-env');
+const fetch = require('node-fetch');
+
+const BASE = 'https://services.leadconnectorhq.com';
+const TOKEN = process.env.GHL_API_KEY || process.env.GHL_ACCESS_TOKEN;
+const LOCATION_ID = process.env.GHL_LOCATION_ID || process.env.LOCATION_ID;
+
+// Try the configured version first, then known alternates.
+const VERSIONS = [
+  process.env.GHL_OBJECTS_API_VERSION,
+  '2021-07-28',
+  '2023-02-21',
+].filter(Boolean);
+
+if (!TOKEN) {
+  console.error('Missing GHL_API_KEY (or GHL_ACCESS_TOKEN).');
+  process.exit(1);
+}
+if (!LOCATION_ID) {
+  console.error('Missing GHL_LOCATION_ID (or LOCATION_ID).');
+  process.exit(1);
+}
+
+async function call(version, path, init = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    method: init.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Version: version,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: init.body ? JSON.stringify(init.body) : undefined,
+  });
+  const text = await res.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { raw: text };
+  }
+  return { ok: res.ok, status: res.status, json };
+}
+
+async function resolveVersion() {
+  for (const v of VERSIONS) {
+    const r = await call(v, `/objects/?locationId=${encodeURIComponent(LOCATION_ID)}`);
+    console.log(`  Version ${v} -> HTTP ${r.status}`);
+    if (r.ok) return { version: v, objectsResponse: r.json };
+  }
+  return null;
+}
+
+function looksLikeProperty(s) {
+  return !!s && /propert/i.test(s);
+}
+
+async function main() {
+  console.log('=== GHL Custom Objects discovery ===');
+  console.log('Resolving API Version header...');
+  const resolved = await resolveVersion();
+  if (!resolved) {
+    console.error('\nNo Version header succeeded. Check token/location id and GHL custom-objects access.');
+    process.exit(1);
+  }
+  const { version, objectsResponse } = resolved;
+  console.log(`\n✅ Using Version: ${version}\n`);
+
+  const objects = objectsResponse.objects || objectsResponse.customObjects || objectsResponse.data || [];
+  console.log(`Found ${objects.length} object(s):`);
+  for (const o of objects) {
+    const flag = looksLikeProperty(o.key) || looksLikeProperty(o.labels?.singular) || looksLikeProperty(o.labels?.plural)
+      ? '  <-- looks like Properties'
+      : '';
+    console.log(`  • key=${o.key}  labels=${JSON.stringify(o.labels)}${flag}`);
+  }
+
+  const prop = objects.find(
+    (o) => looksLikeProperty(o.key) || looksLikeProperty(o.labels?.singular) || looksLikeProperty(o.labels?.plural)
+  );
+  const key = process.env.GHL_PROPERTY_OBJECT_KEY || prop?.key;
+  if (!key) {
+    console.error('\nCould not auto-detect a Properties object. Set GHL_PROPERTY_OBJECT_KEY to one of the keys above.');
+    process.exit(1);
+  }
+  console.log(`\nUsing object key: ${key}`);
+
+  // Schema
+  const schema = await call(
+    version,
+    `/objects/${encodeURIComponent(key)}?locationId=${encodeURIComponent(LOCATION_ID)}&fetchProperties=true`
+  );
+  const schemaObj = schema.json.object || schema.json;
+  const fields = schema.json.fields || schemaObj.fields || schemaObj.properties || [];
+  console.log(`\n--- Schema fields (${fields.length}) ---`);
+  for (const f of fields) {
+    console.log(`  id=${f.id}  fieldKey=${f.fieldKey || f.key}  name=${f.name}  type=${f.dataType}`);
+  }
+
+  // One sample record
+  const search = await call(version, `/objects/${encodeURIComponent(key)}/records/search`, {
+    method: 'POST',
+    body: { locationId: LOCATION_ID, page: 1, pageLimit: 1 },
+  });
+  const records = search.json.records || search.json.data || [];
+  console.log(`\n--- Sample record (total=${search.json.total ?? records.length}) ---`);
+  console.log(JSON.stringify(records[0] || {}, null, 2));
+
+  console.log('\n--- Suggested .env block ---');
+  console.log(`GHL_OBJECTS_API_VERSION=${version}`);
+  console.log(`GHL_PROPERTY_OBJECT_KEY=${key}`);
+  console.log(
+    '# Optionally pin fields (else they are auto-detected by name):\n' +
+      '# GHL_PROP_FIELD_NAME=\n# GHL_PROP_FIELD_ADDRESS=\n# GHL_PROP_FIELD_DESCRIPTION=\n' +
+      '# GHL_PROP_FIELD_RENT=\n# GHL_PROP_FIELD_BEDROOMS=\n# GHL_PROP_FIELD_BATHROOMS=\n' +
+      '# GHL_PROP_FIELD_SQFT=\n# GHL_PROP_FIELD_AVAILABLE=\n# GHL_PROP_FIELD_IMAGES=\n# GHL_PROP_FIELD_AMENITIES='
+  );
+  console.log('\nDone.');
+}
+
+main().catch((err) => {
+  console.error('Discovery failed:', err);
+  process.exit(1);
+});

--- a/scripts/import-active-tenants.js
+++ b/scripts/import-active-tenants.js
@@ -1,0 +1,124 @@
+// Import active tenants from GoHighLevel into Firestore `users` (role: tenant).
+//
+// CLI parity with the admin "Import active from GHL" button
+// (pages/api/admin/import-tenants.ts). Canonical logic lives in
+// lib/ghl-sync.ts (importActiveTenantsFromGHL); this is a compact JS port for
+// ops/seed use. Records only — no Firebase Auth accounts are created.
+//
+// Usage:
+//   node scripts/import-active-tenants.js            # writes
+//   node scripts/import-active-tenants.js --dry      # preview, no writes
+//   TENANT_TAG=active node scripts/import-active-tenants.js
+
+require('./load-env');
+const fetch = require('node-fetch');
+const admin = require('firebase-admin');
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.applicationDefault(),
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || 'rental-tracker-app-2026',
+  });
+}
+const db = admin.firestore();
+
+const TOKEN = process.env.GHL_API_KEY || process.env.GHL_ACCESS_TOKEN;
+const LOC = process.env.GHL_LOCATION_ID || process.env.LOCATION_ID;
+const TAG = process.env.TENANT_TAG || 'active';
+const DRY = process.argv.includes('--dry') || process.argv.includes('--dry-run');
+
+if (!TOKEN || !LOC) {
+  console.error('Missing GHL_API_KEY/GHL_ACCESS_TOKEN or GHL_LOCATION_ID/LOCATION_ID.');
+  process.exit(1);
+}
+
+const norm = (s) => (s || '').toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+
+async function searchTag(tag) {
+  let page = 1;
+  const all = [];
+  while (page <= 50) {
+    const r = await fetch('https://services.leadconnectorhq.com/contacts/search', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}`, Version: '2021-07-28', 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ locationId: LOC, page, pageLimit: 100, filters: [{ field: 'tags', operator: 'contains', value: tag }] }),
+    });
+    const d = await r.json();
+    const cs = d.contacts || [];
+    all.push(...cs);
+    const total = d.total != null ? d.total : all.length;
+    if (cs.length < 100) break;
+    if (total && all.length >= total) break;
+    page++;
+    await new Promise((res) => setTimeout(res, 500));
+  }
+  return all;
+}
+
+async function main() {
+  console.log(`--- Importing '${TAG}' tenants -> Firestore ${DRY ? '(DRY RUN — no writes)' : ''} ---`);
+  const contacts = await searchTag(TAG);
+  console.log(`Found ${contacts.length} '${TAG}' contacts.`);
+
+  const props = (await db.collection('properties').get()).docs
+    .map((d) => ({ id: d.id, name: d.data().name || '', addr: norm(d.data().address) }))
+    .filter((p) => p.addr);
+
+  let created = 0, updated = 0, skipped = 0, matched = 0, unmatched = 0;
+
+  for (const c of contacts) {
+    if (!c.email) { skipped++; continue; }
+
+    const ex = await db.collection('users').where('email', '==', c.email).limit(1).get();
+    const isUpdate = !ex.empty;
+    const existing = isUpdate ? ex.docs[0].data() : null;
+    if (existing && (existing.role === 'admin' || existing.role === 'super-admin')) { skipped++; continue; }
+
+    const ref = isUpdate ? ex.docs[0].ref : db.collection('users').doc(`ghl-${c.id}`);
+
+    const ta = norm(c.address1 || c.address);
+    let match;
+    if (ta && ta.length >= 5) {
+      const hit = props.find((p) => p.addr === ta || p.addr.startsWith(ta) || ta.startsWith(p.addr));
+      if (hit) { match = hit; matched++; } else { unmatched++; }
+    }
+
+    const displayName = c.contactName || [c.firstName, c.lastName].filter(Boolean).join(' ') || c.email;
+    const getCF = (id) => (c.customFields || []).find((f) => f.id === id)?.value;
+    const FIELD = { LEASE_START: 'xflK4edwKFVm1pHLJxew', LEASE_END: 'nMzB4QirjN9XP6BQwp0N', LEASE_ACTIVE: 'KMpvAs09LKwF1mQoY6LV', MONTHLY_RENT: 'r9QRb2yRF9i0CjCDhpNA' };
+    const activeRaw = getCF(FIELD.LEASE_ACTIVE);
+
+    const data = {
+      email: c.email,
+      displayName,
+      role: 'tenant',
+      ghlContactId: c.id,
+      phoneNumber: c.phone || null,
+      address: c.address1 || c.address || null,
+      city: c.city || null,
+      state: c.state || null,
+      zip: c.postalCode || null,
+      monthlyRent: getCF(FIELD.MONTHLY_RENT) ?? null,
+      leaseStart: getCF(FIELD.LEASE_START) || null,
+      leaseEnd: getCF(FIELD.LEASE_END) || null,
+      isLeaseActive: Array.isArray(activeRaw) ? activeRaw.length > 0 : Boolean(activeRaw),
+      source: 'ghl',
+      lastSyncedAt: new Date().toISOString(),
+    };
+    if (match && !(existing && existing.propertyIds && existing.propertyIds.length)) {
+      data.propertyIds = [match.id];
+      data.unit = (existing && existing.unit) || match.name;
+    }
+    if (!isUpdate) data.createdAt = new Date().toISOString();
+
+    if (!DRY) await ref.set(data, { merge: true });
+    if (isUpdate) updated++; else created++;
+    if (!DRY) await new Promise((res) => setTimeout(res, 100));
+  }
+
+  console.log(`\n${DRY ? 'DRY RUN complete' : 'Done'}. created ${created}, updated ${updated}, skipped ${skipped} (no-email/admin) · matched ${matched}, unmatched ${unmatched}.`);
+}
+
+if (require.main === module) {
+  main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });
+}

--- a/scripts/load-env.js
+++ b/scripts/load-env.js
@@ -38,6 +38,9 @@ function loadEnv(file) {
   }
 }
 
-loadEnv();
+// Load .env.local first (local-only secrets, e.g. GOOGLE_APPLICATION_CREDENTIALS)
+// then .env. Real shell env always wins; earlier loads win over later ones.
+loadEnv('.env.local');
+loadEnv('.env');
 
 module.exports = { loadEnv };

--- a/scripts/load-env.js
+++ b/scripts/load-env.js
@@ -1,0 +1,43 @@
+// Minimal, dependency-free .env loader for standalone node scripts.
+//
+// Next.js loads .env automatically, but plain `node scripts/foo.js` does not.
+// Require this at the top of a script to populate process.env from .env
+// (existing real env vars always win, so CI/shell overrides still work).
+
+const fs = require('fs');
+const path = require('path');
+
+function loadEnv(file) {
+  const envPath = path.resolve(process.cwd(), file || '.env');
+  if (!fs.existsSync(envPath)) return;
+
+  const content = fs.readFileSync(envPath, 'utf8');
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const withoutExport = line.startsWith('export ') ? line.slice(7) : line;
+    const eq = withoutExport.indexOf('=');
+    if (eq === -1) continue;
+
+    const key = withoutExport.slice(0, eq).trim();
+    let value = withoutExport.slice(eq + 1).trim();
+
+    // Strip surrounding quotes.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    // Don't clobber values already provided by the real environment.
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadEnv();
+
+module.exports = { loadEnv };

--- a/scripts/sync-ghl-properties.js
+++ b/scripts/sync-ghl-properties.js
@@ -1,0 +1,274 @@
+// Bulk-sync the GoHighLevel "Properties" custom object into Firestore.
+//
+// CLI parity with the admin "Sync from GHL" button (pages/api/admin/sync-properties.ts).
+// Canonical mapping logic lives in lib/ghl-properties.ts; this is a compact JS
+// port for ops use. Writes via Firebase Admin (Application Default Credentials).
+//
+// Usage:
+//   GHL_API_KEY=pit-xxx GHL_LOCATION_ID=loc-xxx node scripts/sync-ghl-properties.js
+//   (or `npm run sync:ghl-properties`)
+
+require('./load-env');
+const fetch = require('node-fetch');
+const admin = require('firebase-admin');
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.applicationDefault(),
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || 'rental-tracker-app-2026',
+  });
+}
+const db = admin.firestore();
+
+const BASE = 'https://services.leadconnectorhq.com';
+const TOKEN = process.env.GHL_API_KEY || process.env.GHL_ACCESS_TOKEN;
+const LOCATION_ID = process.env.GHL_LOCATION_ID || process.env.LOCATION_ID;
+const VERSIONS = [process.env.GHL_OBJECTS_API_VERSION, '2021-07-28', '2023-02-21'].filter(Boolean);
+
+if (!TOKEN || !LOCATION_ID) {
+  console.error('Missing GHL_API_KEY/GHL_ACCESS_TOKEN or GHL_LOCATION_ID/LOCATION_ID.');
+  process.exit(1);
+}
+
+let VERSION = VERSIONS[0];
+
+async function call(path, init = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    method: init.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Version: VERSION,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: init.body ? JSON.stringify(init.body) : undefined,
+  });
+  const text = await res.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = {};
+  }
+  return { ok: res.ok, status: res.status, json };
+}
+
+// ---- compact mapper (mirrors lib/ghl-properties.ts) ----
+const CANDIDATES = {
+  name: ['name', 'property_name', 'title'],
+  address: ['address', 'full_address', 'street_address', 'property_address', 'location'],
+  description: ['description', 'details', 'notes'],
+  rent: ['rent', 'monthly_rent', 'price', 'rent_amount'],
+  bedrooms: ['bedrooms', 'beds', 'bedroom'],
+  bathrooms: ['bathrooms', 'baths', 'bathroom'],
+  squareFeet: ['square_feet', 'squarefeet', 'sqft', 'sq_ft', 'size', 'area'],
+  available: ['available', 'is_available', 'availability', 'vacant', 'status'],
+  images: ['images', 'image', 'photos', 'photo'],
+  amenities: ['amenities', 'features', 'amenity'],
+};
+const FIELD_ENV = {
+  name: process.env.GHL_PROP_FIELD_NAME,
+  address: process.env.GHL_PROP_FIELD_ADDRESS,
+  description: process.env.GHL_PROP_FIELD_DESCRIPTION,
+  rent: process.env.GHL_PROP_FIELD_RENT,
+  bedrooms: process.env.GHL_PROP_FIELD_BEDROOMS,
+  bathrooms: process.env.GHL_PROP_FIELD_BATHROOMS,
+  squareFeet: process.env.GHL_PROP_FIELD_SQFT,
+  available: process.env.GHL_PROP_FIELD_AVAILABLE,
+  images: process.env.GHL_PROP_FIELD_IMAGES,
+  amenities: process.env.GHL_PROP_FIELD_AMENITIES,
+};
+
+const normKey = (k) => {
+  const last = k.includes('.') ? k.slice(k.lastIndexOf('.') + 1) : k;
+  return last.toLowerCase().replace(/[^a-z0-9]/g, '');
+};
+
+function buildLookup(properties) {
+  const byId = {};
+  const byKey = {};
+  if (Array.isArray(properties)) {
+    for (const f of properties) {
+      if (!f) continue;
+      if (f.id != null) byId[String(f.id)] = f.value;
+      const k = f.fieldKey || f.key || f.name;
+      if (k != null) byKey[normKey(String(k))] = f.value;
+    }
+  } else if (properties && typeof properties === 'object') {
+    for (const [k, v] of Object.entries(properties)) {
+      byId[k] = v;
+      byKey[normKey(k)] = v;
+    }
+  }
+  return { byId, byKey };
+}
+
+function pickVal(lookup, ref, candidates) {
+  if (ref) {
+    if (lookup.byId[ref] !== undefined) return lookup.byId[ref];
+    const nk = normKey(ref);
+    if (lookup.byKey[nk] !== undefined) return lookup.byKey[nk];
+  }
+  for (const c of candidates) {
+    const v = lookup.byKey[normKey(c)];
+    if (v !== undefined) return v;
+  }
+  const keys = Object.keys(lookup.byKey);
+  for (const c of candidates) {
+    const nc = normKey(c);
+    const hit = keys.find((k) => k === nc || k.includes(nc));
+    if (hit && lookup.byKey[hit] !== undefined) return lookup.byKey[hit];
+  }
+  return undefined;
+}
+
+const toStr = (v) =>
+  v == null ? '' : Array.isArray(v) ? v.map(toStr).filter(Boolean).join(', ') : String(v).trim();
+const toNum = (v) => {
+  if (v == null) return 0;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : 0;
+  if (typeof v === 'string') {
+    const n = parseFloat(v.replace(/[^0-9.\-]/g, ''));
+    return Number.isFinite(n) ? n : 0;
+  }
+  // GHL MONETORY/currency fields arrive as { currency, value }.
+  if (typeof v === 'object') {
+    const inner = v.value != null ? v.value : v.amount;
+    return inner != null ? toNum(inner) : 0;
+  }
+  return 0;
+};
+const toArr = (v) => {
+  if (v == null) return [];
+  if (Array.isArray(v)) return v.map((i) => (i && typeof i === 'object' ? toStr(i.url || i.value || i.name) : toStr(i))).filter(Boolean);
+  if (typeof v === 'string') return v.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);
+  return [];
+};
+const toAvailable = (v) => {
+  if (v == null) return true;
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'number') return v !== 0;
+  if (Array.isArray(v)) return v.length > 0;
+  const s = String(v).toLowerCase().trim();
+  if (['occupied', 'rented', 'unavailable', 'no', 'false', '0', 'inactive', 'leased'].includes(s)) return false;
+  return true;
+};
+
+function mapRecord(rec) {
+  const id = String(rec.id || rec._id || rec.recordId || '');
+  const props = rec.properties || rec.customFields || rec.data || rec.values || {};
+  const lookup = buildLookup(props);
+  return {
+    id,
+    name: toStr(pickVal(lookup, FIELD_ENV.name, CANDIDATES.name)),
+    address: toStr(pickVal(lookup, FIELD_ENV.address, CANDIDATES.address)),
+    description: toStr(pickVal(lookup, FIELD_ENV.description, CANDIDATES.description)),
+    rent: toNum(pickVal(lookup, FIELD_ENV.rent, CANDIDATES.rent)),
+    bedrooms: toNum(pickVal(lookup, FIELD_ENV.bedrooms, CANDIDATES.bedrooms)),
+    bathrooms: toNum(pickVal(lookup, FIELD_ENV.bathrooms, CANDIDATES.bathrooms)),
+    squareFeet: toNum(pickVal(lookup, FIELD_ENV.squareFeet, CANDIDATES.squareFeet)),
+    available: toAvailable(pickVal(lookup, FIELD_ENV.available, CANDIDATES.available)),
+    images: toArr(pickVal(lookup, FIELD_ENV.images, CANDIDATES.images)),
+    amenities: toArr(pickVal(lookup, FIELD_ENV.amenities, CANDIDATES.amenities)),
+  };
+}
+
+async function resolveVersionAndKey() {
+  for (const v of VERSIONS) {
+    VERSION = v;
+    const r = await call(`/objects/?locationId=${encodeURIComponent(LOCATION_ID)}`);
+    if (!r.ok) continue;
+    if (process.env.GHL_PROPERTY_OBJECT_KEY) return process.env.GHL_PROPERTY_OBJECT_KEY;
+    const objects = r.json.objects || r.json.customObjects || r.json.data || [];
+    const isProp = (s) => !!s && /propert/i.test(s);
+    const match = objects.find(
+      (o) => isProp(o.key) || isProp(o.labels && o.labels.singular) || isProp(o.labels && o.labels.plural)
+    );
+    if (match) return match.key;
+  }
+  return process.env.GHL_PROPERTY_OBJECT_KEY || null;
+}
+
+async function fetchAll(key) {
+  const all = [];
+  let page = 1;
+  const pageLimit = 100;
+  while (page <= 100) {
+    const r = await call(`/objects/${encodeURIComponent(key)}/records/search`, {
+      method: 'POST',
+      body: { locationId: LOCATION_ID, page, pageLimit },
+    });
+    if (!r.ok) break;
+    const recs = (r.json.records || r.json.data || []).map((x) => x.record || x);
+    all.push(...recs);
+    const total = r.json.total != null ? r.json.total : (r.json.pageInfo && r.json.pageInfo.total);
+    if (recs.length < pageLimit) break;
+    if (total && all.length >= total) break;
+    page += 1;
+    await new Promise((res) => setTimeout(res, 200));
+  }
+  return all;
+}
+
+async function main() {
+  const DRY = process.argv.includes('--dry') || process.argv.includes('--dry-run');
+  console.log(`--- Syncing GHL Properties -> Firestore ${DRY ? '(DRY RUN — no writes)' : ''} ---`);
+  const key = await resolveVersionAndKey();
+  if (!key) {
+    console.error('Could not resolve a Properties object key. Run: npm run discover:ghl-properties');
+    process.exit(1);
+  }
+  console.log(`Object key: ${key} (Version ${VERSION})`);
+
+  const records = await fetchAll(key);
+  console.log(`Fetched ${records.length} record(s).`);
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const rec of records) {
+    const m = mapRecord(rec);
+    if (!m.name && !m.address) {
+      skipped++;
+      continue;
+    }
+    const ref = db.collection('properties').doc(`ghl-${m.id}`);
+    const existing = await ref.get();
+    const data = {
+      name: m.name || m.address,
+      address: m.address,
+      description: m.description,
+      rent: m.rent,
+      bedrooms: m.bedrooms,
+      bathrooms: m.bathrooms,
+      squareFeet: m.squareFeet,
+      available: m.available,
+      amenities: m.amenities,
+      ghlObjectId: m.id,
+      ghlObjectKey: key,
+      source: 'ghl',
+      lastSyncedAt: new Date().toISOString(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    };
+    if (m.images.length) data.images = m.images;
+    else if (!existing.exists) data.images = [];
+    if (!existing.exists) data.createdAt = admin.firestore.FieldValue.serverTimestamp();
+
+    if (!DRY) await ref.set(data, { merge: true });
+    if (existing.exists) updated++;
+    else created++;
+    if (!DRY) await new Promise((res) => setTimeout(res, 200));
+  }
+
+  console.log(`\n${DRY ? 'DRY RUN complete' : 'Done'}. ${created} new, ${updated} updated, ${skipped} skipped.`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Sync failed:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { mapRecord };


### PR DESCRIPTION
## Summary
Syncs the GoHighLevel **Properties** custom object (`custom_objects.houses`) into the Firestore `properties` collection and surfaces it across the app. **GHL is the source of truth; the app is read-only for properties.**

## What changed
- **`lib/ghl-properties.ts`** — new GHL Objects API client: object discovery, schema fetch, paginated record search, and a defensive, schema-agnostic mapper to the `Property` shape. Handles GHL `MONETORY` fields (`{currency,value}`) and both `fieldKey`/`id` keying.
- **`lib/ghl-sync.ts`** — `syncGHLPropertiesToFirestore()` upserts `ghl-{recordId}` docs (`source:'ghl'`), idempotent; existing manual docs left untouched (preserves maintenance/ledger/tenant joins).
- **Admin** (`pages/admin/properties.tsx`) — "Sync from GHL" button + result banner + "Synced from GHL" badge; in-app create disabled (`create-property` guarded by `ALLOW_MANUAL_PROPERTY`). New route `pages/api/admin/sync-properties.ts`.
- **Public landing** — `getPublicProperties()` + `pages/api/properties/public.ts` (Admin SDK, **no `firestore.rules` change**) and `FeaturedPropertiesSection` rendered via SSR on `/`.
- **Tenant portal** — shows the real property name (`usePortalData` + `propertyIds` fallback).
- **Scripts** — `discover-ghl-properties`, `sync-ghl-properties` (+ `--dry`), `load-env`; `.gitignore` now blocks service-account keys.

## Verification (done end-to-end)
- Discovery resolved the live schema (object `custom_objects.houses`, API Version `2021-07-28`, 28 records).
- Mapper validated against real records (incl. the monetary-rent fix).
- Synced **28 properties** to the `rental-tracker-app-2026` Firestore (7 available / 21 occupied).
- Public landing renders the 7 available listings server-side (`GET / 200`).
- `npm run build` is green.

## Notes / follow-ups
- For the **in-production** "Sync from GHL" button to work, `GHL_*` env vars must be set in the hosting backend runtime (local `.env` isn't deployed). Non-blocking — data is already synced; can re-sync locally via `npm run sync:ghl-properties`.
- `available` defaults to `true` when GHL has no such field; existing manual property docs are left in place (dedup/reconciliation deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)