### PR TITLE
Bump Node runtime to 22 and firebase-functions to 7.2.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Next Level Rentals is a property management tenant portal built with Next.js 14, React, TypeScript, and Firebase. It provides a public landing page, tenant portal, and admin dashboard for property management operations.
 
-**Requirements**: Node.js 20
+**Requirements**: Node.js 22
 
 ## Development Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@opentelemetry/api": "1.9.0",
         "firebase": "^10.11.0",
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^7.0.2",
+        "firebase-functions": "^7.2.5",
         "next": "14.2.5",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -27,7 +27,7 @@
         "typescript": "5.4.5"
       },
       "engines": {
-        "node": "20"
+        "node": "22"
       }
     },
     "node_modules/@emnapi/core": {
@@ -4277,9 +4277,9 @@
       "license": "MIT"
     },
     "node_modules/firebase-functions": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.0.2.tgz",
-      "integrity": "sha512-AFAZOn2iMp6X6lvCzEI92/J/JfT2ZAGSHKAfop4btWZdIqeHU40gFwVBGPl53bnqEpuv5VYKirmkxGuPu4OHpA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -4295,7 +4295,21 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/firebase/node_modules/@firebase/auth": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "scripts": {
     "dev": "next dev -p 4000",
@@ -25,7 +25,7 @@
     "@opentelemetry/api": "1.9.0",
     "firebase": "^10.11.0",
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^7.0.2",
+    "firebase-functions": "^7.2.5",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
## Summary
- Move the web-frameworks SSR Cloud Function off the **deprecated `nodejs20`** runtime (decommissioned 2026-10-30) to **`nodejs22`** by bumping `engines.node` — the field that drives the generated function's runtime for this deploy path.
- Bump `firebase-functions` `^7.0.2` → `^7.2.5` to clear the CLI's "outdated version" warning. It is not imported in app source (only packaged into the generated SSR function), so this is build-only.
- Sync the documented requirement in `CLAUDE.md` (Node.js 20 → 22).

## Context
Both items surfaced as non-blocking warnings during the production deploy of #10. Already deployed and verified on production ahead of this PR:
- SSR function now reports **Node.js 22 (2nd Gen)** — `Successful update operation`
- Both the runtime-deprecation and firebase-functions-outdated warnings are gone from deploy output
- Smoke test: homepage `200`, `/api/properties/public` `200` returning live GHL data

## Test Plan
- [x] `next build` passes (full type-check, all routes compile)
- [x] `firebase deploy` succeeds, provisions `nodejs22`
- [x] Live smoke test green (homepage + public API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)