### PR TITLE
Dark theme + sticky table-header fix

### DIFF
--- a/components/Admin/AddPropertyModal.tsx
+++ b/components/Admin/AddPropertyModal.tsx
@@ -520,7 +520,7 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
         }
 
         .modal {
-          background: white;
+          background: var(--color-surface);
           padding: 2rem;
           border-radius: 12px;
           width: 100%;
@@ -537,9 +537,9 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           margin-bottom: 1.5rem;
           position: sticky;
           top: 0;
-          background: white;
+          background: var(--color-surface);
           padding-bottom: 0.5rem;
-          border-bottom: 1px solid #e5e7eb;
+          border-bottom: 1px solid var(--color-border);
         }
 
         .modal__header h2 {
@@ -552,11 +552,11 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           border: none;
           font-size: 1.5rem;
           cursor: pointer;
-          color: #6b7280;
+          color: var(--color-muted);
         }
 
         .close-button:hover {
-          color: #111827;
+          color: var(--color-text);
         }
 
         .modal__form {
@@ -568,7 +568,7 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           display: grid;
           gap: 1rem;
           padding-bottom: 1rem;
-          border-bottom: 1px solid #f3f4f6;
+          border-bottom: 1px solid var(--color-border);
         }
 
         .form-section:last-of-type {
@@ -578,7 +578,7 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
         .form-section h3 {
           margin: 0;
           font-size: 1.1rem;
-          color: #374151;
+          color: var(--color-text);
         }
 
         .form-group {
@@ -595,12 +595,12 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
         label {
           font-weight: 600;
           font-size: 0.9rem;
-          color: #374151;
+          color: var(--color-text);
         }
 
         input, select, textarea {
           padding: 0.75rem;
-          border: 1px solid #d1d5db;
+          border: 1px solid var(--color-border);
           border-radius: 6px;
           font-size: 1rem;
           font-family: inherit;
@@ -608,12 +608,12 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
 
         input:focus, select:focus, textarea:focus {
           outline: none;
-          border-color: var(--color-primary, #6366f1);
-          box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+          border-color: var(--color-primary, #3b9bff);
+          box-shadow: 0 0 0 3px var(--color-primary-light);
         }
 
         input:disabled, select:disabled, textarea:disabled {
-          background: #f9fafb;
+          background: var(--color-surface-elevated);
           cursor: not-allowed;
         }
 
@@ -641,7 +641,7 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           aspect-ratio: 1;
           border-radius: 8px;
           overflow: hidden;
-          border: 1px solid #e5e7eb;
+          border: 1px solid var(--color-border);
         }
 
         :global(.preview-image) {
@@ -701,14 +701,14 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
 
         .custom-amenity button {
           padding: 0.5rem 1rem;
-          background: #f3f4f6;
-          border: 1px solid #d1d5db;
+          background: var(--color-surface-elevated);
+          border: 1px solid var(--color-border);
           border-radius: 6px;
           cursor: pointer;
         }
 
         .custom-amenity button:hover:not(:disabled) {
-          background: #e5e7eb;
+          background: var(--color-border);
         }
 
         .custom-amenities-list {
@@ -723,8 +723,8 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           display: inline-flex;
           align-items: center;
           gap: 0.25rem;
-          background: #e0e7ff;
-          color: #3730a3;
+          background: var(--tag-info-bg);
+          color: var(--tag-info-text);
           padding: 0.25rem 0.5rem;
           border-radius: 4px;
           font-size: 0.875rem;
@@ -735,21 +735,21 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           border: none;
           cursor: pointer;
           font-size: 1rem;
-          color: #3730a3;
+          color: var(--tag-info-text);
         }
 
         /* Progress Bar */
         .progress-bar {
           position: relative;
           height: 24px;
-          background: #f3f4f6;
+          background: var(--color-surface-elevated);
           border-radius: 4px;
           overflow: hidden;
         }
 
         .progress-fill {
           height: 100%;
-          background: var(--color-primary, #6366f1);
+          background: var(--color-primary, #3b9bff);
           transition: width 0.3s ease;
         }
 
@@ -759,13 +759,13 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           left: 50%;
           transform: translate(-50%, -50%);
           font-size: 0.75rem;
-          color: #374151;
+          color: var(--color-text);
         }
 
         .error-message {
-          color: #dc2626;
+          color: var(--color-error);
           font-size: 0.9rem;
-          background: #fef2f2;
+          background: var(--tag-error-bg);
           padding: 0.75rem;
           border-radius: 6px;
         }
@@ -776,20 +776,20 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           gap: 1rem;
           margin-top: 0.5rem;
           padding-top: 1rem;
-          border-top: 1px solid #e5e7eb;
+          border-top: 1px solid var(--color-border);
         }
 
         .outline-button {
           padding: 0.5rem 1rem;
-          background: white;
-          border: 1px solid #d1d5db;
+          background: var(--color-surface);
+          border: 1px solid var(--color-border);
           border-radius: 6px;
           cursor: pointer;
           font-weight: 500;
         }
 
         .outline-button:hover:not(:disabled) {
-          background: #f9fafb;
+          background: var(--color-surface-elevated);
         }
 
         .ghost-button {
@@ -797,17 +797,17 @@ export default function AddPropertyModal({ isOpen, onClose, onSuccess }: AddProp
           background: transparent;
           border: none;
           cursor: pointer;
-          color: #6b7280;
+          color: var(--color-muted);
           font-weight: 500;
         }
 
         .ghost-button:hover:not(:disabled) {
-          color: #111827;
+          color: var(--color-text);
         }
 
         .primary-button {
           padding: 0.75rem 1.5rem;
-          background: var(--color-primary, #6366f1);
+          background: var(--color-primary, #3b9bff);
           color: white;
           border: none;
           border-radius: 6px;

--- a/components/Admin/AddTenantModal.tsx
+++ b/components/Admin/AddTenantModal.tsx
@@ -144,7 +144,7 @@ export default function AddTenantModal({ isOpen, onClose, onSuccess }: AddTenant
         }
 
         .modal {
-          background: white;
+          background: var(--color-surface);
           padding: 2rem;
           border-radius: 12px;
           width: 100%;
@@ -188,13 +188,13 @@ export default function AddTenantModal({ isOpen, onClose, onSuccess }: AddTenant
 
         input, select {
           padding: 0.75rem;
-          border: 1px solid #ccc;
+          border: 1px solid var(--color-border);
           border-radius: 6px;
           font-size: 1rem;
         }
 
         .error-message {
-          color: red;
+          color: var(--color-error);
           font-size: 0.9rem;
         }
 

--- a/components/Admin/LedgerTable.tsx
+++ b/components/Admin/LedgerTable.tsx
@@ -144,14 +144,14 @@ export default function LedgerTable({ entries }: LedgerTableProps) {
         .ledger-container {
           background: var(--color-surface);
           border-radius: var(--radius-lg);
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           overflow: hidden;
         }
 
         .ledger-controls {
           padding: 1rem 1.5rem;
           background: var(--color-surface-elevated);
-          border-bottom: 1px solid rgba(15, 118, 110, 0.12);
+          border-bottom: 1px solid var(--color-border);
           display: flex;
           justify-content: flex-end;
           gap: 1rem;
@@ -200,16 +200,16 @@ export default function LedgerTable({ entries }: LedgerTableProps) {
         }
 
         tbody tr {
-          border-bottom: 1px solid rgba(15, 118, 110, 0.08);
+          border-bottom: 1px solid var(--color-border);
           transition: background 0.2s;
         }
 
         tbody tr:nth-child(even) {
-          background: rgba(15, 118, 110, 0.04);
+          background: var(--color-accent-subtle);
         }
 
         tbody tr:hover {
-          background: rgba(15, 118, 110, 0.08);
+          background: var(--color-accent-subtle-strong);
         }
 
         th {
@@ -221,10 +221,10 @@ export default function LedgerTable({ entries }: LedgerTableProps) {
           user-select: none;
         }
 
-        .tag--error { background: #fee2e2; color: #991b1b; }
-        .tag--warning { background: #fef3c7; color: #92400e; }
-        .tag--success { background: #dcfce7; color: #166534; }
-        .tag--muted { background: #f1f5f9; color: #475569; }
+        .tag--error { background: var(--tag-error-bg); color: var(--tag-error-text); }
+        .tag--warning { background: var(--tag-warning-bg); color: var(--tag-warning-text); }
+        .tag--success { background: var(--tag-success-bg); color: var(--tag-success-text); }
+        .tag--muted { background: var(--tag-neutral-bg); color: var(--tag-neutral-text); }
       `}</style>
     </div>
   );

--- a/components/Admin/LedgerTable.tsx
+++ b/components/Admin/LedgerTable.tsx
@@ -195,7 +195,8 @@ export default function LedgerTable({ entries }: LedgerTableProps) {
         thead th {
           position: sticky;
           top: var(--header-height);
-          z-index: 1;
+          z-index: 2;
+          background: var(--color-surface-elevated);
         }
 
         tbody tr {

--- a/components/Admin/MaintenanceStatusModal.tsx
+++ b/components/Admin/MaintenanceStatusModal.tsx
@@ -236,7 +236,7 @@ export default function MaintenanceStatusModal({
           }
 
           .modal {
-            background: white;
+            background: var(--color-surface);
             border-radius: 12px;
             width: 100%;
             max-width: 700px;
@@ -250,13 +250,13 @@ export default function MaintenanceStatusModal({
             justify-content: space-between;
             align-items: center;
             padding: 1.5rem 2rem;
-            border-bottom: 1px solid #e2e8f0;
+            border-bottom: 1px solid var(--color-border);
           }
 
           .modal__header h2 {
             margin: 0;
             font-size: 1.5rem;
-            color: #1e293b;
+            color: var(--color-text);
           }
 
           .close-button {
@@ -264,25 +264,25 @@ export default function MaintenanceStatusModal({
             border: none;
             font-size: 2rem;
             cursor: pointer;
-            color: #94a3b8;
+            color: var(--color-muted);
             padding: 0;
             line-height: 1;
           }
 
           .close-button:hover {
-            color: #64748b;
+            color: var(--color-text);
           }
 
           .modal__details {
             padding: 1.5rem 2rem;
-            background-color: #f8fafc;
-            border-bottom: 1px solid #e2e8f0;
+            background-color: var(--color-surface-elevated);
+            border-bottom: 1px solid var(--color-border);
           }
 
           .modal__details h3 {
             margin: 0 0 1rem;
             font-size: 1.25rem;
-            color: #1e293b;
+            color: var(--color-text);
           }
 
           .detail-grid {
@@ -302,13 +302,13 @@ export default function MaintenanceStatusModal({
             font-size: 0.75rem;
             font-weight: 600;
             text-transform: uppercase;
-            color: #64748b;
+            color: var(--color-muted);
             letter-spacing: 0.05em;
           }
 
           .detail-value {
             font-size: 0.938rem;
-            color: #1e293b;
+            color: var(--color-text);
           }
 
           .priority-badge {
@@ -322,23 +322,23 @@ export default function MaintenanceStatusModal({
           }
 
           .priority-emergency {
-            background-color: #fee2e2;
-            color: #991b1b;
+            background-color: var(--tag-error-bg);
+            color: var(--tag-error-text);
           }
 
           .priority-high {
-            background-color: #fef3c7;
-            color: #92400e;
+            background-color: var(--tag-warning-bg);
+            color: var(--tag-warning-text);
           }
 
           .priority-medium {
-            background-color: #dbeafe;
-            color: #1e40af;
+            background-color: var(--tag-info-bg);
+            color: var(--tag-info-text);
           }
 
           .priority-low {
-            background-color: #d1fae5;
-            color: #065f46;
+            background-color: var(--tag-success-bg);
+            color: var(--tag-success-text);
           }
 
           .description-section,
@@ -350,9 +350,9 @@ export default function MaintenanceStatusModal({
           .notes-text {
             margin: 0.5rem 0 0;
             padding: 0.75rem;
-            background: white;
+            background: var(--color-surface);
             border-radius: 6px;
-            color: #475569;
+            color: var(--color-text);
             line-height: 1.6;
             font-size: 0.938rem;
           }
@@ -377,17 +377,17 @@ export default function MaintenanceStatusModal({
           label {
             font-weight: 600;
             font-size: 0.938rem;
-            color: #1e293b;
+            color: var(--color-text);
           }
 
           input,
           select,
           textarea {
             padding: 0.75rem;
-            border: 1px solid #cbd5e1;
+            border: 1px solid var(--color-border);
             border-radius: 8px;
             font-size: 0.938rem;
-            color: #1e293b;
+            color: var(--color-text);
             font-family: inherit;
           }
 
@@ -396,7 +396,7 @@ export default function MaintenanceStatusModal({
           textarea:focus {
             outline: none;
             border-color: var(--color-primary);
-            box-shadow: 0 0 0 3px rgba(108, 92, 231, 0.1);
+            box-shadow: 0 0 0 3px var(--color-primary-light);
           }
 
           textarea {
@@ -405,14 +405,14 @@ export default function MaintenanceStatusModal({
 
           .form-hint {
             font-size: 0.813rem;
-            color: #94a3b8;
+            color: var(--color-muted);
           }
 
           .error-message {
-            color: #dc2626;
+            color: var(--color-error);
             font-size: 0.875rem;
             padding: 0.75rem;
-            background: #fee2e2;
+            background: var(--tag-error-bg);
             border-radius: 6px;
             margin: 0;
           }
@@ -422,7 +422,7 @@ export default function MaintenanceStatusModal({
             justify-content: flex-end;
             gap: 1rem;
             padding-top: 1rem;
-            border-top: 1px solid #e2e8f0;
+            border-top: 1px solid var(--color-border);
           }
 
           .outline-button,
@@ -436,14 +436,14 @@ export default function MaintenanceStatusModal({
           }
 
           .outline-button {
-            background: white;
-            border: 1px solid #cbd5e1;
-            color: #475569;
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            color: var(--color-text);
           }
 
           .outline-button:hover:not(:disabled) {
-            border-color: #94a3b8;
-            background-color: #f8fafc;
+            border-color: var(--color-muted);
+            background-color: var(--color-surface-elevated);
           }
 
           .primary-button {

--- a/components/Admin/PaymentPlanCard.tsx
+++ b/components/Admin/PaymentPlanCard.tsx
@@ -51,10 +51,10 @@ export default function PaymentPlanCard({ plan }: PaymentPlanCardProps) {
 
             <style jsx>{`
         .plan-card {
-          background: white;
+          background: var(--color-surface);
           padding: 1.5rem;
           border-radius: var(--radius-lg);
-          border: 1px solid rgba(15, 23, 42, 0.08);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-sm);
         }
 
@@ -68,12 +68,12 @@ export default function PaymentPlanCard({ plan }: PaymentPlanCardProps) {
         h3 {
           margin: 0;
           font-size: 1.1rem;
-          color: #1e293b;
+          color: var(--color-text);
         }
 
         .plan-dates {
           font-size: 0.85rem;
-          color: #64748b;
+          color: var(--color-muted);
           margin: 0.25rem 0 0;
         }
 
@@ -85,8 +85,8 @@ export default function PaymentPlanCard({ plan }: PaymentPlanCardProps) {
           text-transform: uppercase;
         }
 
-        .status--active { background: #dcfce7; color: #166534; }
-        .status--broken { background: #fee2e2; color: #991b1b; }
+        .status--active { background: var(--tag-success-bg); color: var(--tag-success-text); }
+        .status--broken { background: var(--tag-error-bg); color: var(--tag-error-text); }
 
         .plan-stats {
           display: grid;
@@ -102,7 +102,7 @@ export default function PaymentPlanCard({ plan }: PaymentPlanCardProps) {
 
         .stat-label {
           font-size: 0.75rem;
-          color: #64748b;
+          color: var(--color-muted);
           text-transform: uppercase;
           letter-spacing: 0.05em;
         }
@@ -110,7 +110,7 @@ export default function PaymentPlanCard({ plan }: PaymentPlanCardProps) {
         .stat-value {
           font-size: 1.25rem;
           font-weight: 700;
-          color: #1e293b;
+          color: var(--color-text);
         }
 
         .progress-container {
@@ -119,7 +119,7 @@ export default function PaymentPlanCard({ plan }: PaymentPlanCardProps) {
 
         .progress-bar {
           height: 8px;
-          background: #f1f5f9;
+          background: var(--color-surface-elevated);
           border-radius: 4px;
           overflow: hidden;
           margin-bottom: 0.5rem;
@@ -133,12 +133,12 @@ export default function PaymentPlanCard({ plan }: PaymentPlanCardProps) {
 
         .progress-text {
           font-size: 0.8rem;
-          color: #64748b;
+          color: var(--color-muted);
         }
 
         .installments-preview h4 {
           font-size: 0.85rem;
-          color: #1e293b;
+          color: var(--color-text);
           margin-bottom: 0.75rem;
         }
 
@@ -153,7 +153,7 @@ export default function PaymentPlanCard({ plan }: PaymentPlanCardProps) {
           justify-content: space-between;
           padding: 0.5rem 0;
           font-size: 0.9rem;
-          border-top: 1px solid #f1f5f9;
+          border-top: 1px solid var(--color-border);
         }
       `}</style>
         </div>

--- a/components/Admin/RecordPaymentModal.tsx
+++ b/components/Admin/RecordPaymentModal.tsx
@@ -226,7 +226,7 @@ export default function RecordPaymentModal({
         }
 
         .modal {
-          background: white;
+          background: var(--color-surface);
           padding: 2rem;
           border-radius: 12px;
           width: 100%;
@@ -289,20 +289,20 @@ export default function RecordPaymentModal({
         select:focus {
           outline: none;
           border-color: var(--color-primary);
-          box-shadow: 0 0 0 3px rgba(108, 92, 231, 0.1);
+          box-shadow: 0 0 0 3px var(--color-primary-light);
         }
 
         input:disabled,
         select:disabled {
-          background-color: #f3f4f6;
+          background-color: var(--color-surface-elevated);
           cursor: not-allowed;
         }
 
         .error-message {
-          color: #dc2626;
+          color: var(--color-error);
           font-size: 0.9rem;
           padding: 0.75rem;
-          background: #fee2e2;
+          background: var(--tag-error-bg);
           border-radius: 6px;
           margin: 0;
         }

--- a/components/Admin/RentTracking/MonthlyPaymentGrid.tsx
+++ b/components/Admin/RentTracking/MonthlyPaymentGrid.tsx
@@ -263,8 +263,8 @@ export default function MonthlyPaymentGrid({ properties, onRecordPayment }: Mont
         }
 
         .export-btn:hover {
-          background: rgba(15, 118, 110, 0.08);
-          border-color: rgba(15, 118, 110, 0.3);
+          background: var(--color-accent-subtle);
+          border-color: var(--color-border);
           transform: translateY(-1px);
         }
 
@@ -304,22 +304,22 @@ export default function MonthlyPaymentGrid({ properties, onRecordPayment }: Mont
         }
 
         th.sortable:hover {
-          background: rgba(15, 118, 110, 0.08);
+          background: var(--color-accent-subtle);
         }
 
         td {
           padding: 1rem 1.5rem;
-          border-top: 1px solid rgba(15, 118, 110, 0.08);
+          border-top: 1px solid var(--color-border);
           font-size: 0.938rem;
           color: var(--color-text);
         }
 
         tbody tr:nth-child(even) {
-          background: rgba(15, 118, 110, 0.04);
+          background: var(--color-accent-subtle);
         }
 
         tbody tr:hover {
-          background: rgba(15, 118, 110, 0.08);
+          background: var(--color-accent-subtle);
         }
 
         .property-cell {
@@ -357,23 +357,23 @@ export default function MonthlyPaymentGrid({ properties, onRecordPayment }: Mont
         }
 
         .status-badge--paid {
-          background: rgba(15, 118, 110, 0.12);
-          color: #0f766e;
+          background: var(--tag-success-bg);
+          color: var(--tag-success-text);
         }
 
         .status-badge--pending {
-          background: rgba(3, 105, 161, 0.12);
-          color: #075985;
+          background: var(--tag-info-bg);
+          color: var(--tag-info-text);
         }
 
         .status-badge--overdue {
-          background: #fee2e2;
-          color: #991b1b;
+          background: var(--tag-error-bg);
+          color: var(--tag-error-text);
         }
 
         .status-badge--partial {
-          background: #fef3c7;
-          color: #92400e;
+          background: var(--tag-warning-bg);
+          color: var(--tag-warning-text);
         }
 
         .action-buttons {
@@ -397,8 +397,8 @@ export default function MonthlyPaymentGrid({ properties, onRecordPayment }: Mont
 
         .btn-view:hover,
         .btn-record:hover {
-          background: rgba(15, 118, 110, 0.08);
-          border-color: rgba(15, 118, 110, 0.3);
+          background: var(--color-accent-subtle);
+          border-color: var(--color-border);
           transform: translateY(-1px);
         }
 

--- a/components/Admin/RentTracking/MonthlyPaymentGrid.tsx
+++ b/components/Admin/RentTracking/MonthlyPaymentGrid.tsx
@@ -293,7 +293,8 @@ export default function MonthlyPaymentGrid({ properties, onRecordPayment }: Mont
           white-space: nowrap;
           position: sticky;
           top: var(--header-height);
-          z-index: 1;
+          z-index: 2;
+          background: var(--color-surface-elevated);
         }
 
         th.sortable {

--- a/components/Admin/RentTracking/PaymentFilters.tsx
+++ b/components/Admin/RentTracking/PaymentFilters.tsx
@@ -150,9 +150,9 @@ export default function PaymentFilters({
 
             <style jsx>{`
         .payment-filters {
-          background: white;
+          background: var(--color-surface);
           border-radius: var(--radius-lg);
-          border: 1px solid #e2e8f0;
+          border: 1px solid var(--color-border);
           padding: 1.5rem 2rem;
           margin-bottom: 2rem;
         }
@@ -173,7 +173,7 @@ export default function PaymentFilters({
         .filter-group label {
           font-size: 0.813rem;
           font-weight: 600;
-          color: #64748b;
+          color: var(--color-muted);
           text-transform: uppercase;
           letter-spacing: 0.05em;
         }
@@ -181,11 +181,11 @@ export default function PaymentFilters({
         .select-input,
         .search-input {
           padding: 0.75rem 1rem;
-          border: 1px solid #e2e8f0;
+          border: 1px solid var(--color-border);
           border-radius: var(--radius-md);
           font-size: 0.938rem;
-          color: #1e293b;
-          background: white;
+          color: var(--color-text);
+          background: var(--color-surface);
           transition: all 0.2s;
         }
 
@@ -193,11 +193,11 @@ export default function PaymentFilters({
         .search-input:focus {
           outline: none;
           border-color: var(--color-primary);
-          box-shadow: 0 0 0 3px rgba(108, 92, 231, 0.1);
+          box-shadow: 0 0 0 3px var(--color-primary-light);
         }
 
         .search-input::placeholder {
-          color: #94a3b8;
+          color: var(--color-muted);
         }
 
         .sort-controls {
@@ -211,8 +211,8 @@ export default function PaymentFilters({
 
         .sort-order-btn {
           padding: 0.75rem 1rem;
-          background: #f8fafc;
-          border: 1px solid #e2e8f0;
+          background: var(--color-surface);
+          border: 1px solid var(--color-border);
           border-radius: var(--radius-md);
           font-size: 1.25rem;
           cursor: pointer;
@@ -221,7 +221,7 @@ export default function PaymentFilters({
         }
 
         .sort-order-btn:hover {
-          background: #e2e8f0;
+          background: var(--color-surface-elevated);
         }
 
         .view-toggle {
@@ -236,8 +236,8 @@ export default function PaymentFilters({
         .toggle-btn {
           flex: 1;
           padding: 0.75rem;
-          background: #f8fafc;
-          border: 1px solid #e2e8f0;
+          background: var(--color-surface);
+          border: 1px solid var(--color-border);
           border-radius: var(--radius-md);
           font-size: 1.25rem;
           cursor: pointer;
@@ -245,7 +245,7 @@ export default function PaymentFilters({
         }
 
         .toggle-btn:hover {
-          background: #e2e8f0;
+          background: var(--color-surface-elevated);
         }
 
         .toggle-btn.active {

--- a/components/Admin/RentTracking/PaymentSummaryStats.tsx
+++ b/components/Admin/RentTracking/PaymentSummaryStats.tsx
@@ -19,14 +19,14 @@ export default function PaymentSummaryStats({ summary, loading }: PaymentSummary
             justify-content: center;
             gap: 1rem;
             padding: 3rem;
-            background: white;
+            background: var(--color-surface);
             border-radius: var(--radius-lg);
-            border: 1px solid #e2e8f0;
+            border: 1px solid var(--color-border);
           }
           .spinner {
             width: 24px;
             height: 24px;
-            border: 3px solid #e2e8f0;
+            border: 3px solid var(--color-border);
             border-top-color: var(--color-primary);
             border-radius: 50%;
             animation: spin 0.8s linear infinite;
@@ -43,35 +43,35 @@ export default function PaymentSummaryStats({ summary, loading }: PaymentSummary
         {
             label: 'Total Properties',
             value: summary.totalProperties,
-            color: '#64748b',
+            color: 'var(--color-muted)',
             icon: '🏘️'
         },
         {
             label: 'Paid',
             value: summary.paidCount,
             percentage: summary.totalProperties > 0 ? (summary.paidCount / summary.totalProperties * 100).toFixed(1) : '0',
-            color: '#10b981',
+            color: 'var(--color-success)',
             icon: '✅'
         },
         {
             label: 'Pending',
             value: summary.pendingCount,
             percentage: summary.totalProperties > 0 ? (summary.pendingCount / summary.totalProperties * 100).toFixed(1) : '0',
-            color: '#3b82f6',
+            color: 'var(--color-info)',
             icon: '⏳'
         },
         {
             label: 'Overdue',
             value: summary.overdueCount,
             percentage: summary.totalProperties > 0 ? (summary.overdueCount / summary.totalProperties * 100).toFixed(1) : '0',
-            color: '#ef4444',
+            color: 'var(--color-error)',
             icon: '⚠️'
         },
         {
             label: 'Partial',
             value: summary.partialCount,
             percentage: summary.totalProperties > 0 ? (summary.partialCount / summary.totalProperties * 100).toFixed(1) : '0',
-            color: '#f59e0b',
+            color: 'var(--color-warning)',
             icon: '📊'
         }
     ];
@@ -112,9 +112,9 @@ export default function PaymentSummaryStats({ summary, loading }: PaymentSummary
 
             <style jsx>{`
         .summary-stats {
-          background: white;
+          background: var(--color-surface);
           border-radius: var(--radius-lg);
-          border: 1px solid #e2e8f0;
+          border: 1px solid var(--color-border);
           padding: 2rem;
           margin-bottom: 2rem;
         }
@@ -131,7 +131,7 @@ export default function PaymentSummaryStats({ summary, loading }: PaymentSummary
           align-items: center;
           gap: 1rem;
           padding: 1rem;
-          background: #f8fafc;
+          background: var(--color-surface-elevated);
           border-radius: var(--radius-md);
           transition: transform 0.2s, box-shadow 0.2s;
         }
@@ -152,7 +152,7 @@ export default function PaymentSummaryStats({ summary, loading }: PaymentSummary
 
         .stat-label {
           font-size: 0.813rem;
-          color: #64748b;
+          color: var(--color-muted);
           text-transform: uppercase;
           letter-spacing: 0.05em;
           font-weight: 600;

--- a/components/Admin/RentTracking/PropertyPaymentCard.tsx
+++ b/components/Admin/RentTracking/PropertyPaymentCard.tsx
@@ -16,15 +16,15 @@ export default function PropertyPaymentCard({
     const getStatusColor = (status: string) => {
         switch (status) {
             case 'paid':
-                return { bg: '#dcfce7', text: '#166534', border: '#86efac' };
+                return { bg: 'var(--tag-success-bg)', text: 'var(--tag-success-text)', border: 'var(--color-border)' };
             case 'pending':
-                return { bg: '#dbeafe', text: '#1e40af', border: '#93c5fd' };
+                return { bg: 'var(--tag-info-bg)', text: 'var(--tag-info-text)', border: 'var(--color-border)' };
             case 'overdue':
-                return { bg: '#fee2e2', text: '#991b1b', border: '#fca5a5' };
+                return { bg: 'var(--tag-error-bg)', text: 'var(--tag-error-text)', border: 'var(--color-border)' };
             case 'partial':
-                return { bg: '#fef3c7', text: '#92400e', border: '#fcd34d' };
+                return { bg: 'var(--tag-warning-bg)', text: 'var(--tag-warning-text)', border: 'var(--color-border)' };
             default:
-                return { bg: '#f1f5f9', text: '#475569', border: '#cbd5e1' };
+                return { bg: 'var(--tag-neutral-bg)', text: 'var(--tag-neutral-text)', border: 'var(--color-border)' };
         }
     };
 
@@ -133,9 +133,9 @@ export default function PropertyPaymentCard({
 
             <style jsx>{`
         .property-card {
-          background: white;
+          background: var(--color-surface);
           border-radius: var(--radius-lg);
-          border: 1px solid #e2e8f0;
+          border: 1px solid var(--color-border);
           overflow: hidden;
           transition: transform 0.2s, box-shadow 0.2s;
         }
@@ -147,7 +147,7 @@ export default function PropertyPaymentCard({
 
         .card-header {
           padding: 1.5rem;
-          border-bottom: 1px solid #f1f5f9;
+          border-bottom: 1px solid var(--color-border);
           display: flex;
           justify-content: space-between;
           align-items: flex-start;
@@ -162,19 +162,19 @@ export default function PropertyPaymentCard({
           margin: 0 0 0.5rem;
           font-size: 1.25rem;
           font-weight: 700;
-          color: #1e293b;
+          color: var(--color-text);
         }
 
         .property-address {
           margin: 0 0 0.5rem;
           font-size: 0.875rem;
-          color: #64748b;
+          color: var(--color-muted);
         }
 
         .tenant-name {
           margin: 0;
           font-size: 0.875rem;
-          color: #475569;
+          color: var(--color-text);
           font-weight: 500;
         }
 
@@ -206,27 +206,27 @@ export default function PropertyPaymentCard({
 
         .amount-row .label {
           font-size: 0.875rem;
-          color: #64748b;
+          color: var(--color-muted);
           font-weight: 500;
         }
 
         .amount-row .value {
           font-size: 1.125rem;
           font-weight: 700;
-          color: #1e293b;
+          color: var(--color-text);
         }
 
         .amount-row .value.paid {
-          color: #10b981;
+          color: var(--color-success);
         }
 
         .amount-row .value.remaining {
-          color: #ef4444;
+          color: var(--color-error);
         }
 
         .progress-bar {
           height: 8px;
-          background: #f1f5f9;
+          background: var(--color-surface-elevated);
           border-radius: 9999px;
           overflow: hidden;
           margin: 1rem 0;
@@ -244,7 +244,7 @@ export default function PropertyPaymentCard({
           gap: 0.5rem;
           margin-top: 1rem;
           padding-top: 1rem;
-          border-top: 1px solid #f1f5f9;
+          border-top: 1px solid var(--color-border);
         }
 
         .detail-item {
@@ -254,19 +254,19 @@ export default function PropertyPaymentCard({
         }
 
         .detail-label {
-          color: #64748b;
+          color: var(--color-muted);
           font-weight: 500;
         }
 
         .detail-value {
-          color: #475569;
+          color: var(--color-text);
           font-weight: 600;
         }
 
         .card-footer {
           padding: 1rem 1.5rem;
-          background: #f8fafc;
-          border-top: 1px solid #e2e8f0;
+          background: var(--color-surface-elevated);
+          border-top: 1px solid var(--color-border);
           display: flex;
           gap: 0.75rem;
           justify-content: flex-end;
@@ -284,14 +284,14 @@ export default function PropertyPaymentCard({
         }
 
         .btn-secondary {
-          background: white;
-          color: #475569;
-          border: 1px solid #e2e8f0;
+          background: var(--color-surface);
+          color: var(--color-text);
+          border: 1px solid var(--color-border);
         }
 
         .btn-secondary:hover {
-          background: #f8fafc;
-          border-color: #cbd5e1;
+          background: var(--color-surface-elevated);
+          border-color: var(--color-border);
         }
 
         .btn-primary {

--- a/components/Admin/TenantPortfolioTable.tsx
+++ b/components/Admin/TenantPortfolioTable.tsx
@@ -72,7 +72,8 @@ export default function TenantPortfolioTable({ tenants }: TenantPortfolioTablePr
         thead th {
           position: sticky;
           top: var(--header-height);
-          z-index: 1;
+          z-index: 2;
+          background: var(--color-surface-elevated);
         }
 
         tbody tr:nth-child(even) {

--- a/components/Admin/TenantPortfolioTable.tsx
+++ b/components/Admin/TenantPortfolioTable.tsx
@@ -47,7 +47,7 @@ export default function TenantPortfolioTable({ tenants }: TenantPortfolioTablePr
         .table-wrapper {
           overflow-x: auto;
           border-radius: var(--radius-md);
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           background: var(--color-surface);
           box-shadow: var(--shadow-sm);
         }
@@ -65,7 +65,7 @@ export default function TenantPortfolioTable({ tenants }: TenantPortfolioTablePr
         }
 
         thead tr {
-          border-bottom: 1px solid rgba(15, 118, 110, 0.12);
+          border-bottom: 1px solid var(--color-border);
           background: var(--color-surface-elevated);
         }
 
@@ -77,11 +77,11 @@ export default function TenantPortfolioTable({ tenants }: TenantPortfolioTablePr
         }
 
         tbody tr:nth-child(even) {
-          background: rgba(15, 118, 110, 0.04);
+          background: var(--color-accent-subtle);
         }
 
         tbody tr + tr {
-          border-top: 1px solid rgba(15, 118, 110, 0.08);
+          border-top: 1px solid var(--color-border);
         }
 
         th {

--- a/components/Admin/WorkOrderTable.tsx
+++ b/components/Admin/WorkOrderTable.tsx
@@ -72,7 +72,8 @@ export default function WorkOrderTable({ workOrders }: WorkOrderTableProps) {
         thead th {
           position: sticky;
           top: var(--header-height);
-          z-index: 1;
+          z-index: 2;
+          background: var(--color-surface-elevated);
         }
 
         tbody tr:nth-child(even) {

--- a/components/Admin/WorkOrderTable.tsx
+++ b/components/Admin/WorkOrderTable.tsx
@@ -47,7 +47,7 @@ export default function WorkOrderTable({ workOrders }: WorkOrderTableProps) {
         .table-wrapper {
           overflow-x: auto;
           border-radius: var(--radius-md);
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           background: var(--color-surface);
           box-shadow: var(--shadow-sm);
         }
@@ -65,7 +65,7 @@ export default function WorkOrderTable({ workOrders }: WorkOrderTableProps) {
         }
 
         thead tr {
-          border-bottom: 1px solid rgba(15, 118, 110, 0.12);
+          border-bottom: 1px solid var(--color-border);
           background: var(--color-surface-elevated);
         }
 
@@ -77,11 +77,11 @@ export default function WorkOrderTable({ workOrders }: WorkOrderTableProps) {
         }
 
         tbody tr:nth-child(even) {
-          background: rgba(15, 118, 110, 0.04);
+          background: var(--color-accent-subtle);
         }
 
         tbody tr + tr {
-          border-top: 1px solid rgba(15, 118, 110, 0.08);
+          border-top: 1px solid var(--color-border);
         }
 
         th {

--- a/components/Auth/AuthGuard.tsx
+++ b/components/Auth/AuthGuard.tsx
@@ -26,7 +26,7 @@ const LoadingState = () => (
         width: 56px;
         height: 56px;
         border-radius: 50%;
-        border: 6px solid rgba(108, 92, 231, 0.18);
+        border: 6px solid var(--color-border);
         border-top-color: var(--color-primary);
         animation: spin 0.8s linear infinite;
       }

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -90,7 +90,7 @@ export default function ChatInput() {
 
         .chat-input__container:focus-within {
           border-color: var(--color-primary);
-          box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+          box-shadow: 0 0 0 3px var(--color-primary-light);
         }
 
         .chat-input__textarea {
@@ -132,7 +132,7 @@ export default function ChatInput() {
 
         .chat-input__send:hover:not(:disabled) {
           transform: scale(1.05);
-          box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+          box-shadow: 0 4px 12px var(--color-primary-light);
         }
 
         .chat-input__send:active:not(:disabled) {

--- a/components/Chat/ChatWidget.tsx
+++ b/components/Chat/ChatWidget.tsx
@@ -70,8 +70,8 @@ export default function ChatWidget() {
           align-items: center;
           justify-content: center;
           box-shadow:
-            0 4px 12px rgba(15, 118, 110, 0.35),
-            0 0 0 0 rgba(15, 118, 110, 0.35);
+            0 4px 12px var(--color-primary-light),
+            0 0 0 0 var(--color-primary-light);
           transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
           z-index: 1000;
         }
@@ -79,8 +79,8 @@ export default function ChatWidget() {
         .chat-fab:hover {
           transform: scale(1.05);
           box-shadow:
-            0 6px 20px rgba(15, 118, 110, 0.45),
-            0 0 0 0 rgba(15, 118, 110, 0.35);
+            0 6px 20px var(--color-primary-light),
+            0 0 0 0 var(--color-primary-light);
         }
 
         .chat-fab:active {

--- a/components/Chat/ChatWindow.tsx
+++ b/components/Chat/ChatWindow.tsx
@@ -225,7 +225,7 @@ export default function ChatWindow() {
         }
 
         .chat-window__action-btn--close:hover {
-          background: rgba(239, 68, 68, 0.8);
+          background: var(--color-error);
         }
 
         .chat-window__messages {
@@ -259,7 +259,7 @@ export default function ChatWindow() {
           font-size: 1.75rem;
           font-weight: 600;
           margin-bottom: 16px;
-          box-shadow: 0 4px 12px rgba(15, 118, 110, 0.28);
+          box-shadow: 0 4px 12px var(--color-primary-light);
         }
 
         .chat-window__welcome-title {

--- a/components/Landing/CityEventsSection.tsx
+++ b/components/Landing/CityEventsSection.tsx
@@ -71,7 +71,7 @@ export default function CityEventsSection() {
           font-size: 0.8rem;
           letter-spacing: 0.28em;
           font-weight: 700;
-          color: rgba(15, 118, 110, 0.7);
+          color: var(--color-primary);
           margin-bottom: 0.75rem;
         }
 
@@ -98,7 +98,7 @@ export default function CityEventsSection() {
           padding: 1.75rem;
           display: grid;
           gap: 1rem;
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-sm);
         }
 

--- a/components/Landing/FeaturedPropertiesSection.tsx
+++ b/components/Landing/FeaturedPropertiesSection.tsx
@@ -111,7 +111,7 @@ export default function FeaturedPropertiesSection({ properties }: Props) {
         .property-card {
           background: var(--color-surface-elevated);
           border-radius: var(--radius-lg);
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-sm);
           overflow: hidden;
           display: flex;
@@ -178,7 +178,7 @@ export default function FeaturedPropertiesSection({ properties }: Props) {
           align-items: center;
           margin-top: auto;
           padding-top: 1rem;
-          border-top: 1px solid rgba(15, 118, 110, 0.12);
+          border-top: 1px solid var(--color-border);
         }
 
         .property-card__rent {

--- a/components/Landing/MaintenanceScheduleSection.tsx
+++ b/components/Landing/MaintenanceScheduleSection.tsx
@@ -94,7 +94,7 @@ export default function MaintenanceScheduleSection() {
           top: 0.5rem;
           bottom: 0.5rem;
           width: 2px;
-          background: rgba(15, 118, 110, 0.25);
+          background: var(--color-border);
         }
 
         .maintenance__item {
@@ -111,7 +111,7 @@ export default function MaintenanceScheduleSection() {
           height: 16px;
           border-radius: 999px;
           background: var(--color-primary);
-          box-shadow: 0 0 0 4px rgba(15, 118, 110, 0.18);
+          box-shadow: 0 0 0 4px var(--color-accent-subtle);
         }
 
         .maintenance__item-header {

--- a/components/Landing/TenantCTASection.tsx
+++ b/components/Landing/TenantCTASection.tsx
@@ -24,7 +24,7 @@ export default function TenantCTASection() {
       <style jsx>{`
         .tenant-cta {
           padding: clamp(3.5rem, 7vw, 5rem) 1.5rem clamp(4rem, 8vw, 6rem);
-          background: linear-gradient(135deg, rgba(15, 118, 110, 0.12), rgba(3, 105, 161, 0.12));
+          background: linear-gradient(135deg, var(--color-accent-subtle), var(--color-accent-subtle));
         }
 
         .tenant-cta__inner {
@@ -34,7 +34,7 @@ export default function TenantCTASection() {
           border-radius: clamp(1.5rem, 4vw, 2.5rem);
           padding: clamp(2.5rem, 5vw, 3rem);
           box-shadow: var(--shadow-md);
-          border: 1px solid rgba(15, 118, 110, 0.16);
+          border: 1px solid var(--color-border);
           display: grid;
           gap: clamp(1.5rem, 4vw, 2.5rem);
         }
@@ -57,11 +57,11 @@ export default function TenantCTASection() {
         }
 
         .tenant-cta__primary {
-          box-shadow: 0 18px 28px rgba(15, 118, 110, 0.25);
+          box-shadow: 0 18px 28px var(--color-accent-subtle);
         }
 
         .tenant-cta__outline {
-          border-color: rgba(15, 118, 110, 0.4);
+          border-color: var(--color-border);
         }
       `}</style>
     </section>

--- a/components/Landing/TenantHero.tsx
+++ b/components/Landing/TenantHero.tsx
@@ -222,16 +222,16 @@ export default function TenantHero() {
           position: relative;
           overflow: hidden;
           padding: clamp(4rem, 8vw, 6.5rem) 1.5rem;
-          background: radial-gradient(circle at top left, rgba(15, 118, 110, 0.18), transparent 55%),
-            linear-gradient(120deg, rgba(3, 105, 161, 0.12), transparent 65%),
+          background: radial-gradient(circle at top left, rgba(47, 128, 237, 0.18), transparent 55%),
+            linear-gradient(120deg, rgba(92, 176, 255, 0.12), transparent 65%),
             var(--color-surface);
         }
 
         .tenant-hero__gradient {
           position: absolute;
           inset: 0;
-          background: radial-gradient(circle at 20% 20%, rgba(20, 184, 166, 0.18), transparent 55%),
-            radial-gradient(circle at 80% 10%, rgba(3, 105, 161, 0.14), transparent 50%);
+          background: radial-gradient(circle at 20% 20%, rgba(47, 128, 237, 0.16), transparent 55%),
+            radial-gradient(circle at 80% 10%, rgba(92, 176, 255, 0.14), transparent 50%);
           pointer-events: none;
         }
 
@@ -256,7 +256,7 @@ export default function TenantHero() {
           font-size: 0.85rem;
           letter-spacing: 0.28em;
           font-weight: 700;
-          color: rgba(15, 118, 110, 0.75);
+          color: var(--color-primary);
           margin-bottom: 1rem;
         }
 
@@ -379,14 +379,14 @@ export default function TenantHero() {
         }
 
         .tenant-hero__card {
-          background: rgba(15, 23, 42, 0.82);
-          color: white;
+          background: var(--color-surface-elevated);
+          color: var(--color-text);
+          border: 1px solid var(--color-border);
           border-radius: clamp(1.5rem, 3vw, 2.25rem);
           padding: clamp(2rem, 4vw, 2.75rem);
           display: grid;
           gap: 1.75rem;
-          box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
-          backdrop-filter: blur(8px);
+          box-shadow: var(--shadow-lg);
           align-self: start;
         }
 
@@ -405,8 +405,8 @@ export default function TenantHero() {
           font-weight: 700;
           padding: 0.4rem 0.8rem;
           border-radius: 999px;
-          background: rgba(96, 165, 250, 0.18);
-          color: #bfdbfe;
+          background: var(--tag-info-bg);
+          color: var(--tag-info-text);
         }
 
         .tenant-hero__card-list {
@@ -427,7 +427,7 @@ export default function TenantHero() {
         }
 
         .tenant-hero__card-list p {
-          color: rgba(226, 232, 240, 0.82);
+          color: var(--color-muted);
           line-height: 1.6;
         }
 
@@ -440,7 +440,7 @@ export default function TenantHero() {
         }
 
         .tenant-hero__card-footer a {
-          color: #bae6fd;
+          color: var(--color-primary);
           font-weight: 600;
         }
 

--- a/components/Landing/TenantHero.tsx
+++ b/components/Landing/TenantHero.tsx
@@ -302,7 +302,7 @@ export default function TenantHero() {
         }
 
         .tenant-hero__primary {
-          box-shadow: 0 18px 35px rgba(15, 118, 110, 0.2);
+          box-shadow: 0 18px 35px rgba(59, 155, 255, 0.2);
         }
 
         .tenant-hero__trust {
@@ -315,7 +315,7 @@ export default function TenantHero() {
         .trust-pill {
           padding: 0.35rem 0.85rem;
           border-radius: 999px;
-          background: rgba(15, 118, 110, 0.12);
+          background: var(--color-accent-subtle-strong);
           color: var(--color-primary);
           font-size: 0.85rem;
           font-weight: 600;
@@ -340,7 +340,7 @@ export default function TenantHero() {
           font-size: 0.9rem;
           text-transform: uppercase;
           letter-spacing: 0.12em;
-          color: rgba(15, 118, 110, 0.7);
+          color: var(--color-primary);
           font-weight: 700;
         }
 

--- a/components/Landing/TenantResourcesSection.tsx
+++ b/components/Landing/TenantResourcesSection.tsx
@@ -97,7 +97,7 @@ export default function TenantResourcesSection() {
           padding: 1.75rem;
           display: grid;
           gap: 1rem;
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-sm);
         }
 
@@ -106,7 +106,7 @@ export default function TenantResourcesSection() {
           text-transform: uppercase;
           letter-spacing: 0.18em;
           font-weight: 700;
-          color: rgba(15, 118, 110, 0.65);
+          color: var(--color-primary);
         }
 
         .resource-card h3 {

--- a/components/Landing/WeatherAlertsSection.tsx
+++ b/components/Landing/WeatherAlertsSection.tsx
@@ -46,8 +46,8 @@ export default function WeatherAlertsSection() {
       <style jsx>{`
         .weather-alerts {
           padding: clamp(3.5rem, 7vw, 5.5rem) 1.5rem;
-          background: linear-gradient(160deg, rgba(15, 118, 110, 0.95), rgba(3, 105, 161, 0.9));
-          color: white;
+          background: linear-gradient(160deg, rgba(47, 128, 237, 0.12), transparent 55%), var(--color-background);
+          color: var(--color-text);
         }
 
         .weather-alerts__inner {
@@ -62,7 +62,7 @@ export default function WeatherAlertsSection() {
         }
 
         .section-eyebrow {
-          color: rgba(226, 232, 240, 0.85);
+          color: var(--color-primary);
         }
 
         .weather-alerts__header h2 {
@@ -71,7 +71,7 @@ export default function WeatherAlertsSection() {
         }
 
         .weather-alerts__header p {
-          color: rgba(226, 232, 240, 0.9);
+          color: var(--color-muted);
           line-height: 1.7;
         }
 
@@ -82,13 +82,12 @@ export default function WeatherAlertsSection() {
         }
 
         .weather-card {
-          background: rgba(15, 23, 42, 0.45);
+          background: var(--color-surface-elevated);
           border-radius: var(--radius-lg);
           padding: 1.85rem;
           display: grid;
           gap: 1.25rem;
-          border: 1px solid rgba(226, 232, 240, 0.2);
-          backdrop-filter: blur(8px);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-md);
         }
 
@@ -97,7 +96,8 @@ export default function WeatherAlertsSection() {
           align-items: center;
           padding: 0.45rem 0.9rem;
           border-radius: 999px;
-          background: rgba(248, 250, 252, 0.16);
+          background: var(--tag-info-bg);
+          color: var(--tag-info-text);
           font-weight: 600;
           letter-spacing: 0.1em;
           text-transform: uppercase;
@@ -106,13 +106,13 @@ export default function WeatherAlertsSection() {
 
         .weather-card__window {
           margin-top: 0.5rem;
-          color: rgba(226, 232, 240, 0.75);
+          color: var(--color-muted);
           font-weight: 500;
         }
 
         .weather-card__summary {
           line-height: 1.6;
-          color: rgba(226, 232, 240, 0.9);
+          color: var(--color-text);
         }
 
         .weather-card__actions {
@@ -126,7 +126,7 @@ export default function WeatherAlertsSection() {
         .weather-card__actions li {
           position: relative;
           padding-left: 1.4rem;
-          color: rgba(226, 232, 240, 0.85);
+          color: var(--color-muted);
           line-height: 1.6;
         }
 
@@ -138,12 +138,12 @@ export default function WeatherAlertsSection() {
           width: 0.5rem;
           height: 0.5rem;
           border-radius: 999px;
-          background: rgba(191, 219, 254, 0.9);
+          background: var(--color-accent);
         }
 
         .weather-card__footer {
           font-size: 0.9rem;
-          color: rgba(226, 232, 240, 0.85);
+          color: var(--color-muted);
         }
       `}</style>
     </section>

--- a/components/Notifications/NotificationBell.tsx
+++ b/components/Notifications/NotificationBell.tsx
@@ -137,7 +137,7 @@ export default function NotificationBell() {
         }
 
         .notification-bell:hover {
-          background-color: rgba(0, 0, 0, 0.05);
+          background-color: var(--color-accent-subtle);
           color: var(--color-primary);
         }
 

--- a/components/Notifications/NotificationCenter.tsx
+++ b/components/Notifications/NotificationCenter.tsx
@@ -377,13 +377,13 @@ export default function NotificationCenter() {
         }
 
         .notification-card:hover {
-          border-color: rgba(15, 118, 110, 0.2);
+          border-color: var(--color-border);
           box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
         }
 
         .notification-card.unread {
           background-color: var(--color-primary-light);
-          border-color: rgba(15, 118, 110, 0.3);
+          border-color: var(--color-border);
         }
 
         .card-header {

--- a/components/Notifications/NotificationDropdown.tsx
+++ b/components/Notifications/NotificationDropdown.tsx
@@ -270,7 +270,7 @@ export default function NotificationDropdown({
         }
 
         .notification-item.unread:hover {
-          background-color: rgba(15, 118, 110, 0.18);
+          background-color: var(--color-accent-subtle-strong);
         }
 
         .notification-icon {

--- a/components/Notifications/NotificationPreferencesModal.tsx
+++ b/components/Notifications/NotificationPreferencesModal.tsx
@@ -285,7 +285,7 @@ export default function NotificationPreferencesModal({
             left: 0;
             right: 0;
             bottom: 0;
-            background: rgba(0, 0, 0, 0.5);
+            background: var(--overlay-background);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -293,7 +293,7 @@ export default function NotificationPreferencesModal({
           }
 
           .modal {
-            background: white;
+            background: var(--color-surface);
             border-radius: 12px;
             width: 100%;
             max-width: 600px;
@@ -307,13 +307,13 @@ export default function NotificationPreferencesModal({
             justify-content: space-between;
             align-items: center;
             padding: 1.5rem 2rem;
-            border-bottom: 1px solid #e2e8f0;
+            border-bottom: 1px solid var(--color-border);
           }
 
           .modal__header h2 {
             margin: 0;
             font-size: 1.5rem;
-            color: #1e293b;
+            color: var(--color-text);
           }
 
           .close-button {
@@ -321,13 +321,13 @@ export default function NotificationPreferencesModal({
             border: none;
             font-size: 2rem;
             cursor: pointer;
-            color: #94a3b8;
+            color: var(--color-muted);
             padding: 0;
             line-height: 1;
           }
 
           .close-button:hover {
-            color: #64748b;
+            color: var(--color-muted);
           }
 
           .modal__content {
@@ -336,7 +336,7 @@ export default function NotificationPreferencesModal({
 
           .description {
             margin: 0 0 2rem;
-            color: #64748b;
+            color: var(--color-muted);
             line-height: 1.6;
           }
 
@@ -351,7 +351,7 @@ export default function NotificationPreferencesModal({
           .spinner {
             width: 48px;
             height: 48px;
-            border: 4px solid #e2e8f0;
+            border: 4px solid var(--color-border);
             border-top-color: var(--color-primary);
             border-radius: 50%;
             animation: spin 0.8s linear infinite;
@@ -367,7 +367,7 @@ export default function NotificationPreferencesModal({
           .preference-section {
             margin-bottom: 2rem;
             padding-bottom: 2rem;
-            border-bottom: 1px solid #e2e8f0;
+            border-bottom: 1px solid var(--color-border);
           }
 
           .preference-section:last-of-type {
@@ -384,13 +384,13 @@ export default function NotificationPreferencesModal({
           .section-header h3 {
             margin: 0;
             font-size: 1.125rem;
-            color: #1e293b;
+            color: var(--color-text);
           }
 
           .section-note {
             margin: 0.5rem 0 0;
             font-size: 0.875rem;
-            color: #94a3b8;
+            color: var(--color-muted);
           }
 
           .toggle-switch {
@@ -413,7 +413,7 @@ export default function NotificationPreferencesModal({
             left: 0;
             right: 0;
             bottom: 0;
-            background-color: #cbd5e1;
+            background-color: var(--color-border);
             transition: 0.3s;
             border-radius: 24px;
           }
@@ -456,7 +456,7 @@ export default function NotificationPreferencesModal({
           }
 
           .checkbox-label:hover {
-            background-color: #f8fafc;
+            background-color: var(--color-surface-elevated);
           }
 
           .checkbox-label input[type='checkbox'] {
@@ -467,15 +467,15 @@ export default function NotificationPreferencesModal({
           }
 
           .checkbox-label span {
-            color: #475569;
+            color: var(--color-text);
             font-size: 0.938rem;
           }
 
           .error-message {
-            color: #dc2626;
+            color: var(--tag-error-text);
             font-size: 0.875rem;
             padding: 0.75rem;
-            background: #fee2e2;
+            background: var(--tag-error-bg);
             border-radius: 6px;
             margin: 1rem 0;
           }
@@ -486,7 +486,7 @@ export default function NotificationPreferencesModal({
             gap: 1rem;
             margin-top: 2rem;
             padding-top: 1.5rem;
-            border-top: 1px solid #e2e8f0;
+            border-top: 1px solid var(--color-border);
           }
 
           .outline-button,
@@ -500,14 +500,14 @@ export default function NotificationPreferencesModal({
           }
 
           .outline-button {
-            background: white;
-            border: 1px solid #cbd5e1;
-            color: #475569;
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            color: var(--color-text);
           }
 
           .outline-button:hover:not(:disabled) {
-            border-color: #94a3b8;
-            background-color: #f8fafc;
+            border-color: var(--color-border);
+            background-color: var(--color-surface-elevated);
           }
 
           .primary-button {

--- a/components/Notifications/PushPermissionPrompt.tsx
+++ b/components/Notifications/PushPermissionPrompt.tsx
@@ -118,7 +118,7 @@ export default function PushPermissionPrompt() {
           bottom: 2rem;
           right: 2rem;
           max-width: 400px;
-          background: white;
+          background: var(--color-surface);
           border-radius: 12px;
           box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
           z-index: 1000;
@@ -197,7 +197,7 @@ export default function PushPermissionPrompt() {
         }
 
         .dismiss-button:hover:not(:disabled) {
-          border-color: rgba(15, 118, 110, 0.3);
+          border-color: var(--color-border);
           background-color: var(--color-surface-elevated);
         }
 

--- a/components/Portal/LandlordPortal.tsx
+++ b/components/Portal/LandlordPortal.tsx
@@ -130,7 +130,7 @@ export default function LandlordPortal() {
         .hero-content h1 {
             font-size: 2.5rem;
             margin: 0.5rem 0;
-            color: #111827;
+            color: var(--color-text);
         }
         .hero-content p {
             color: var(--color-muted);
@@ -149,9 +149,9 @@ export default function LandlordPortal() {
         }
 
         .property-card {
-          background: white;
+          background: var(--color-surface);
           border-radius: var(--radius-lg);
-          border: 1px solid rgba(15, 23, 42, 0.08);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-sm);
           overflow: hidden;
           transition: transform 0.2s;
@@ -164,7 +164,7 @@ export default function LandlordPortal() {
         .property-image {
           height: 200px;
           position: relative;
-          background: #f1f5f9;
+          background: var(--color-surface-elevated);
         }
 
         .image-placeholder {
@@ -172,7 +172,7 @@ export default function LandlordPortal() {
           display: flex;
           align-items: center;
           justify-content: center;
-          color: #94a3b8;
+          color: var(--color-muted);
         }
 
         .status-tag {
@@ -193,14 +193,14 @@ export default function LandlordPortal() {
           padding: 1.5rem;
         }
 
-        h3 { margin: 0; font-size: 1.25rem; color: #1e293b; }
-        .address { font-size: 0.875rem; color: #64748b; margin: 0.5rem 0 1rem; }
+        h3 { margin: 0; font-size: 1.25rem; color: var(--color-text); }
+        .address { font-size: 0.875rem; color: var(--color-muted); margin: 0.5rem 0 1rem; }
 
         .property-details {
           display: flex;
           gap: 1rem;
           font-size: 0.875rem;
-          color: #475569;
+          color: var(--color-text);
           margin-bottom: 1.5rem;
         }
 
@@ -208,24 +208,24 @@ export default function LandlordPortal() {
           display: flex;
           justify-content: space-between;
           align-items: center;
-          border-top: 1px solid #f1f5f9;
+          border-top: 1px solid var(--color-border);
           padding-top: 1rem;
         }
 
-        .rent { font-weight: 700; color: #1e293b; font-size: 1.1rem; }
+        .rent { font-weight: 700; color: var(--color-text); font-size: 1.1rem; }
 
         .loading-state, .empty-state {
           text-align: center;
           padding: 4rem;
-          color: #64748b;
-          border: 2px dashed #e2e8f0;
+          color: var(--color-muted);
+          border: 2px dashed var(--color-border);
           border-radius: var(--radius-lg);
         }
 
         .secondary-button {
-          background: #f8fafc;
-          border: 1px solid #e2e8f0;
-          color: #475569;
+          background: var(--color-surface);
+          border: 1px solid var(--color-border);
+          color: var(--color-text);
           padding: 0.5rem 1rem;
           border-radius: var(--radius-sm);
           font-size: 0.875rem;

--- a/components/Portal/MaintenanceRequestForm.tsx
+++ b/components/Portal/MaintenanceRequestForm.tsx
@@ -198,7 +198,7 @@ export default function MaintenanceRequestForm({ onSubmit, submitting }: Mainten
           background: var(--color-surface);
           border-radius: var(--radius-lg);
           padding: 2.5rem;
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-md);
           display: grid;
           gap: 1.5rem;
@@ -235,8 +235,8 @@ export default function MaintenanceRequestForm({ onSubmit, submitting }: Mainten
         select:focus,
         textarea:focus {
           outline: none;
-          border-color: rgba(15, 118, 110, 0.45);
-          box-shadow: 0 0 0 4px rgba(15, 118, 110, 0.12);
+          border-color: var(--color-border);
+          box-shadow: 0 0 0 4px var(--color-accent-subtle);
         }
 
         .maintenance-form__grid {
@@ -259,7 +259,7 @@ export default function MaintenanceRequestForm({ onSubmit, submitting }: Mainten
 
         .field-error {
           font-size: 0.85rem;
-          color: #dc2626;
+          color: var(--color-error);
           font-weight: 600;
         }
 
@@ -273,7 +273,7 @@ export default function MaintenanceRequestForm({ onSubmit, submitting }: Mainten
         }
 
         .maintenance-form__error {
-          color: #dc2626;
+          color: var(--color-error);
           font-weight: 600;
         }
 

--- a/components/Portal/QuickActions.tsx
+++ b/components/Portal/QuickActions.tsx
@@ -45,7 +45,7 @@ export default function QuickActions({ actions }: QuickActionsProps) {
           padding: 1.75rem;
           border-radius: var(--radius-md);
           background: var(--color-surface);
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-sm);
           display: grid;
           gap: 0.85rem;

--- a/components/Portal/ResidentResources.tsx
+++ b/components/Portal/ResidentResources.tsx
@@ -43,7 +43,7 @@ export default function ResidentResources({ resources }: ResidentResourcesProps)
         .resource-card {
           padding: 1.75rem;
           border-radius: var(--radius-md);
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           background: var(--color-surface);
           box-shadow: var(--shadow-sm);
           display: grid;

--- a/components/Portal/SupportContacts.tsx
+++ b/components/Portal/SupportContacts.tsx
@@ -66,7 +66,7 @@ export default function SupportContacts({ contacts }: SupportContactsProps) {
           padding: 1.75rem;
           border-radius: var(--radius-md);
           background: var(--color-surface);
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
           box-shadow: var(--shadow-sm);
           display: grid;
           gap: 1rem;

--- a/components/common/Card.tsx
+++ b/components/common/Card.tsx
@@ -105,7 +105,7 @@ export default function Card({
           left: 0;
           right: 0;
           bottom: 0;
-          background: rgba(255, 255, 255, 0.9);
+          background: var(--overlay-background);
           display: flex;
           flex-direction: column;
           align-items: center;

--- a/pages/admin/maintenance.tsx
+++ b/pages/admin/maintenance.tsx
@@ -376,42 +376,42 @@ const AdminMaintenancePage: NextPageWithAuth = () => {
         }
 
         .status-submitted {
-          background-color: rgba(2, 132, 199, 0.12);
+          background-color: var(--tag-info-bg);
           color: var(--color-info);
         }
 
         .status-in-progress {
-          background-color: rgba(245, 158, 11, 0.16);
+          background-color: var(--tag-warning-bg);
           color: var(--color-warning);
         }
 
         .status-completed {
-          background-color: rgba(16, 185, 129, 0.12);
+          background-color: var(--tag-success-bg);
           color: var(--color-success);
         }
 
         .status-cancelled {
-          background-color: rgba(239, 68, 68, 0.12);
+          background-color: var(--tag-error-bg);
           color: var(--color-error);
         }
 
         .priority-emergency {
-          background-color: rgba(239, 68, 68, 0.12);
+          background-color: var(--tag-error-bg);
           color: var(--color-error);
         }
 
         .priority-high {
-          background-color: rgba(245, 158, 11, 0.16);
+          background-color: var(--tag-warning-bg);
           color: var(--color-warning);
         }
 
         .priority-medium {
-          background-color: rgba(2, 132, 199, 0.12);
+          background-color: var(--tag-info-bg);
           color: var(--color-info);
         }
 
         .priority-low {
-          background-color: rgba(16, 185, 129, 0.12);
+          background-color: var(--tag-success-bg);
           color: var(--color-success);
         }
 

--- a/pages/admin/properties.tsx
+++ b/pages/admin/properties.tsx
@@ -192,7 +192,7 @@ const PropertiesPage: NextPageWithAuth = () => {
           font-size: 0.7rem;
           font-weight: 600;
           letter-spacing: 0.03em;
-          background: rgba(15, 118, 110, 0.12);
+          background: var(--color-accent-subtle);
           color: var(--color-primary);
         }
 
@@ -249,8 +249,8 @@ const PropertiesPage: NextPageWithAuth = () => {
           backdrop-filter: blur(4px);
         }
 
-        .status--available { background: rgba(15, 118, 110, 0.9); color: white; }
-        .status--occupied { background: rgba(3, 105, 161, 0.9); color: white; }
+        .status--available { background: var(--color-primary); color: white; }
+        .status--occupied { background: var(--color-accent); color: white; }
 
         .property-content {
           padding: 1.5rem;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -158,7 +158,7 @@ export default function LoginPage() {
           display: grid;
           grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
           min-height: calc(100vh - 120px);
-          background: radial-gradient(circle at top right, rgba(15, 118, 110, 0.18), transparent 55%),
+          background: radial-gradient(circle at top right, rgba(47, 128, 237, 0.18), transparent 55%),
             var(--color-surface-elevated);
         }
 
@@ -179,7 +179,7 @@ export default function LoginPage() {
           letter-spacing: 0.28em;
           font-weight: 700;
           font-size: 0.85rem;
-          color: rgba(15, 118, 110, 0.7);
+          color: var(--color-primary);
         }
 
         .auth__intro {
@@ -200,7 +200,7 @@ export default function LoginPage() {
           border-radius: var(--radius-lg);
           padding: 1.25rem 1.5rem;
           box-shadow: var(--shadow-sm);
-          border: 1px solid rgba(15, 118, 110, 0.12);
+          border: 1px solid var(--color-border);
         }
 
         .auth__highlights strong {
@@ -268,8 +268,8 @@ export default function LoginPage() {
 
         .auth-form input:focus {
           outline: none;
-          border-color: rgba(15, 118, 110, 0.45);
-          box-shadow: 0 0 0 4px rgba(15, 118, 110, 0.12);
+          border-color: var(--color-primary);
+          box-shadow: 0 0 0 4px var(--color-primary-light);
         }
 
         .auth-form input:disabled {
@@ -278,7 +278,7 @@ export default function LoginPage() {
         }
 
         .auth-form__error {
-          color: #dc2626;
+          color: var(--color-error);
           font-weight: 500;
         }
 

--- a/pages/portal.tsx
+++ b/pages/portal.tsx
@@ -26,7 +26,7 @@ const PortalPage: NextPageWithAuth = () => {
                     .spinner {
                         width: 40px;
                         height: 40px;
-                        border: 4px solid rgba(108, 92, 231, 0.1);
+                        border: 4px solid var(--color-border);
                         border-top-color: var(--color-primary);
                         border-radius: 50%;
                         animation: spin 1s linear infinite;

--- a/scripts/update_css.js
+++ b/scripts/update_css.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+const cssPath = path.join(__dirname, '../styles/globals.css');
+let css = fs.readFileSync(cssPath, 'utf8');
+
+// Font replacement
+css = css.replace(/Poppins/g, 'Manrope');
+
+// Variables
+// Old Primary: #0f766e -> New Primary: #137fec
+css = css.replace(/#0f766e/g, '#137fec');
+// Old rgb: 15, 118, 110 -> New rgb: 19, 127, 236
+css = css.replace(/15, 118, 110/g, '19, 127, 236');
+
+// Old Secondary: #14b8a6 -> New Secondary: #0f62b8
+css = css.replace(/#14b8a6/g, '#0f62b8');
+// Old rgb: 20, 184, 166 -> New rgb: 15, 98, 184
+css = css.replace(/20, 184, 166/g, '15, 98, 184');
+
+// Old Accent: #0369a1 -> New Accent: #2999ff
+css = css.replace(/#0369a1/g, '#2999ff');
+// Old rgb: 3, 105, 161 -> New rgb: 41, 153, 255
+css = css.replace(/3, 105, 161/g, '41, 153, 255');
+
+// Border Radius
+css = css.replace(/--radius-sm: 10px;/g, '--radius-sm: 8px;');
+css = css.replace(/--radius-md: 14px;/g, '--radius-md: 12px;');
+css = css.replace(/--radius-lg: 18px;/g, '--radius-lg: 16px;');
+css = css.replace(/--radius-xl: 24px;/g, '--radius-xl: 20px;');
+
+fs.writeFileSync(cssPath, css);
+console.log('CSS updated successfully.');

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap');
 
 :root {
   color-scheme: light;
@@ -6,17 +6,17 @@
   --color-background: #f0fdfa;
   --color-surface: #ffffff;
   --color-surface-elevated: #f6fffd;
-  --color-primary: #0f766e;
-  --color-primary-light: rgba(15, 118, 110, 0.12);
+  --color-primary: #137fec;
+  --color-primary-light: rgba(19, 127, 236, 0.12);
   --color-primary-dark: #115e59;
-  --color-secondary: #14b8a6;
-  --color-secondary-light: rgba(20, 184, 166, 0.12);
-  --color-accent: #0369a1;
+  --color-secondary: #0f62b8;
+  --color-secondary-light: rgba(15, 98, 184, 0.12);
+  --color-accent: #2999ff;
   --color-text: #134e4a;
   --color-text-secondary: #0f172a;
   --color-muted: #4b6b6b;
   --color-border: #d9ece8;
-  --color-success: #0f766e;
+  --color-success: #137fec;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
   --color-info: #0284c7;
@@ -30,7 +30,7 @@
 
   /* Chart backgrounds */
   --chart-background: var(--color-surface);
-  --chart-grid: rgba(15, 118, 110, 0.12);
+  --chart-grid: rgba(19, 127, 236, 0.12);
 
   /* Chart data series colors */
   --chart-series-1: var(--color-primary);
@@ -40,12 +40,12 @@
   --chart-series-5: #22c55e;
 
   /* Chart gradients */
-  --chart-gradient-primary: linear-gradient(180deg, rgba(15, 118, 110, 0.2) 0%, rgba(15, 118, 110, 0.05) 100%);
-  --chart-gradient-success: linear-gradient(180deg, rgba(20, 184, 166, 0.2) 0%, rgba(20, 184, 166, 0.05) 100%);
+  --chart-gradient-primary: linear-gradient(180deg, rgba(19, 127, 236, 0.2) 0%, rgba(19, 127, 236, 0.05) 100%);
+  --chart-gradient-success: linear-gradient(180deg, rgba(15, 98, 184, 0.2) 0%, rgba(15, 98, 184, 0.05) 100%);
 
   /* Glassmorphism */
   --glass-background: rgba(255, 255, 255, 0.82);
-  --glass-border: rgba(15, 118, 110, 0.18);
+  --glass-border: rgba(19, 127, 236, 0.18);
   --glass-blur: blur(20px);
 
   /* Shadows */
@@ -54,23 +54,23 @@
   --shadow-md: 0 8px 24px rgba(15, 23, 42, 0.1);
   --shadow-lg: 0 16px 40px rgba(15, 23, 42, 0.12);
   --shadow-xl: 0 24px 60px rgba(15, 23, 42, 0.16);
-  --shadow-glow: 0 0 40px rgba(15, 118, 110, 0.18);
-  --shadow-glow-secondary: 0 0 40px rgba(20, 184, 166, 0.18);
+  --shadow-glow: 0 0 40px rgba(19, 127, 236, 0.18);
+  --shadow-glow-secondary: 0 0 40px rgba(15, 98, 184, 0.18);
 
   /* Layout */
   --radius-xs: 6px;
-  --radius-sm: 10px;
-  --radius-md: 14px;
-  --radius-lg: 18px;
-  --radius-xl: 24px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
   --radius-full: 9999px;
   --max-width: 1150px;
   --max-width-narrow: 960px;
   --header-height: 72px;
 
   /* Typography */
-  --font-heading: 'Poppins', 'Segoe UI', sans-serif;
-  --font-body: 'Poppins', 'Segoe UI', sans-serif;
+  --font-heading: 'Manrope', 'Segoe UI', sans-serif;
+  --font-body: 'Manrope', 'Segoe UI', sans-serif;
 
   /* Animation */
   --transition-fast: 150ms ease;
@@ -88,8 +88,8 @@
 }
 
 @keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 20px rgba(15, 118, 110, 0.2); }
-  50% { box-shadow: 0 0 40px rgba(15, 118, 110, 0.4); }
+  0%, 100% { box-shadow: 0 0 20px rgba(19, 127, 236, 0.2); }
+  50% { box-shadow: 0 0 40px rgba(19, 127, 236, 0.4); }
 }
 
 @keyframes float {
@@ -443,7 +443,7 @@ img {
   font-size: 0.8rem;
   letter-spacing: 0.28em;
   font-weight: 700;
-  color: rgba(15, 118, 110, 0.7);
+  color: rgba(19, 127, 236, 0.7);
   margin-bottom: 0.75rem;
 }
 
@@ -464,35 +464,35 @@ img {
 }
 
 .primary-button {
-  background: linear-gradient(135deg, #0f766e, #0369a1);
+  background: linear-gradient(135deg, #137fec, #2999ff);
   color: #fff;
-  box-shadow: 0 18px 30px rgba(15, 118, 110, 0.25);
+  box-shadow: 0 18px 30px rgba(19, 127, 236, 0.25);
 }
 
 .primary-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 24px 35px rgba(15, 118, 110, 0.35);
+  box-shadow: 0 24px 35px rgba(19, 127, 236, 0.35);
 }
 
 .secondary-button {
   background: var(--color-secondary);
   color: #fff;
-  box-shadow: 0 12px 20px rgba(20, 184, 166, 0.2);
+  box-shadow: 0 12px 20px rgba(15, 98, 184, 0.2);
 }
 
 .secondary-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 26px rgba(20, 184, 166, 0.28);
+  box-shadow: 0 18px 26px rgba(15, 98, 184, 0.28);
 }
 
 .outline-button {
   background: transparent;
   color: var(--color-primary);
-  border: 1px solid rgba(15, 118, 110, 0.6);
+  border: 1px solid rgba(19, 127, 236, 0.6);
 }
 
 .outline-button:hover {
-  background: rgba(15, 118, 110, 0.08);
+  background: rgba(19, 127, 236, 0.08);
 }
 
 .ghost-button {
@@ -508,7 +508,7 @@ img {
 .card {
   background: var(--color-surface);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(15, 118, 110, 0.12);
+  border: 1px solid rgba(19, 127, 236, 0.12);
   box-shadow: var(--shadow-sm);
   padding: 1.75rem;
 }
@@ -554,11 +554,11 @@ img {
 }
 
 .table tbody tr:nth-child(even) {
-  background: rgba(15, 118, 110, 0.04);
+  background: rgba(19, 127, 236, 0.04);
 }
 
 .table tbody tr:hover {
-  background: rgba(15, 118, 110, 0.06);
+  background: rgba(19, 127, 236, 0.06);
 }
 
 .table-wrapper {
@@ -580,7 +580,7 @@ img {
 
 .tag--success {
   background: rgba(16, 185, 129, 0.12);
-  color: #0f766e;
+  color: #137fec;
 }
 
 .tag--warning {
@@ -589,7 +589,7 @@ img {
 }
 
 .tag--info {
-  background: rgba(3, 105, 161, 0.15);
+  background: rgba(41, 153, 255, 0.15);
   color: #075985;
 }
 
@@ -606,7 +606,7 @@ img {
   z-index: 40;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(18px);
-  border-bottom: 1px solid rgba(15, 118, 110, 0.12);
+  border-bottom: 1px solid rgba(19, 127, 236, 0.12);
 }
 
 .site-header__inner {
@@ -666,7 +666,7 @@ img {
 .mobile-nav-toggle:hover {
   background: var(--color-primary-light);
   color: var(--color-primary);
-  border-color: rgba(15, 118, 110, 0.4);
+  border-color: rgba(19, 127, 236, 0.4);
 }
 
 .mobile-nav {
@@ -739,8 +739,8 @@ img {
 
 .hero {
   padding: 6rem 1.5rem 5rem;
-  background: radial-gradient(circle at top left, rgba(20, 184, 166, 0.2), transparent 55%),
-    radial-gradient(circle at top right, rgba(3, 105, 161, 0.16), transparent 50%),
+  background: radial-gradient(circle at top left, rgba(15, 98, 184, 0.2), transparent 55%),
+    radial-gradient(circle at top right, rgba(41, 153, 255, 0.16), transparent 50%),
     linear-gradient(180deg, #ffffff 0%, #f0fdfa 100%);
 }
 
@@ -794,7 +794,7 @@ img {
   background: var(--color-surface);
   padding: 1.25rem 1.5rem;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(15, 118, 110, 0.12);
+  border: 1px solid rgba(19, 127, 236, 0.12);
   box-shadow: 0 15px 30px rgba(15, 23, 42, 0.06);
 }
 
@@ -820,7 +820,7 @@ img {
   padding: 2rem;
   border-radius: var(--radius-lg);
   background: linear-gradient(180deg, #ffffff 0%, #f0fdfa 100%);
-  border: 1px solid rgba(15, 118, 110, 0.1);
+  border: 1px solid rgba(19, 127, 236, 0.1);
   box-shadow: var(--shadow-sm);
 }
 
@@ -914,7 +914,7 @@ img {
   top: -20px;
   left: 20px;
   font-size: 5rem;
-  color: rgba(15, 118, 110, 0.12);
+  color: rgba(19, 127, 236, 0.12);
   font-family: Georgia, 'Times New Roman', serif;
 }
 
@@ -935,7 +935,7 @@ img {
   gap: 2.5rem;
   align-items: center;
   padding: 3rem;
-  background: linear-gradient(135deg, rgba(15, 118, 110, 0.92), rgba(3, 105, 161, 0.92));
+  background: linear-gradient(135deg, rgba(19, 127, 236, 0.92), rgba(41, 153, 255, 0.92));
   color: #fff;
   border-radius: calc(var(--radius-lg) + 6px);
   box-shadow: var(--shadow-md);
@@ -993,7 +993,7 @@ img {
 
 .portal-hero {
   padding: 5rem 1.5rem 3rem;
-  background: linear-gradient(135deg, rgba(15, 118, 110, 0.95), rgba(3, 105, 161, 0.9));
+  background: linear-gradient(135deg, rgba(19, 127, 236, 0.95), rgba(41, 153, 255, 0.9));
   color: #fff;
 }
 
@@ -1068,7 +1068,7 @@ img {
 .stat-card {
   padding: 1.5rem;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(15, 118, 110, 0.14);
+  border: 1px solid rgba(19, 127, 236, 0.14);
   background: var(--color-surface);
   box-shadow: var(--shadow-sm);
 }
@@ -1103,7 +1103,7 @@ img {
 .filter-chip {
   padding: 0.45rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid rgba(15, 118, 110, 0.2);
+  border: 1px solid rgba(19, 127, 236, 0.2);
   background: var(--color-surface);
   color: var(--color-muted);
   font-weight: 500;
@@ -1112,9 +1112,9 @@ img {
 }
 
 .filter-chip--active {
-  background: rgba(15, 118, 110, 0.12);
+  background: rgba(19, 127, 236, 0.12);
   color: var(--color-primary);
-  border-color: rgba(15, 118, 110, 0.45);
+  border-color: rgba(19, 127, 236, 0.45);
 }
 
 .maintenance-grid {
@@ -1127,7 +1127,7 @@ img {
   padding: 1.5rem;
   border-radius: var(--radius-md);
   background: linear-gradient(180deg, #ffffff 0%, #f2fbf7 100%);
-  border: 1px solid rgba(15, 118, 110, 0.12);
+  border: 1px solid rgba(19, 127, 236, 0.12);
   box-shadow: var(--shadow-sm);
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,25 +1,45 @@
 @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap');
 
 :root {
-  color-scheme: light;
-  /* Colors - Light Theme */
-  --color-background: #f0fdfa;
-  --color-surface: #ffffff;
-  --color-surface-elevated: #f6fffd;
-  --color-primary: #137fec;
-  --color-primary-light: rgba(19, 127, 236, 0.12);
-  --color-primary-dark: #115e59;
-  --color-secondary: #0f62b8;
-  --color-secondary-light: rgba(15, 98, 184, 0.12);
-  --color-accent: #2999ff;
-  --color-text: #134e4a;
-  --color-text-secondary: #0f172a;
-  --color-muted: #4b6b6b;
-  --color-border: #d9ece8;
-  --color-success: #137fec;
-  --color-warning: #f59e0b;
-  --color-error: #ef4444;
-  --color-info: #0284c7;
+  color-scheme: dark;
+  /* Colors - Dark Theme */
+  --color-background: #0a0f1a;
+  --color-surface: #111827;
+  --color-surface-elevated: #1a2333;
+  --color-primary: #3b9bff;
+  --color-primary-light: rgba(59, 155, 255, 0.16);
+  --color-primary-dark: #1c6fd0;
+  --color-secondary: #2f80ed;
+  --color-secondary-light: rgba(47, 128, 237, 0.16);
+  --color-accent: #5cb0ff;
+  --color-text: #e6edf6;
+  --color-text-secondary: #f3f6fb;
+  --color-muted: #9aa7b8;
+  --color-border: #26303f;
+  --color-success: #22c55e;
+  --color-warning: #f7b733;
+  --color-error: #f87171;
+  --color-info: #38bdf8;
+
+  /* Status tag pairs */
+  --tag-success-bg: rgba(34, 197, 94, 0.16);
+  --tag-success-text: #4ade80;
+  --tag-warning-bg: rgba(247, 183, 51, 0.16);
+  --tag-warning-text: #fbbf24;
+  --tag-error-bg: rgba(248, 113, 113, 0.16);
+  --tag-error-text: #fca5a5;
+  --tag-info-bg: rgba(56, 189, 248, 0.16);
+  --tag-info-text: #7dd3fc;
+  --tag-neutral-bg: rgba(154, 167, 184, 0.14);
+  --tag-neutral-text: #c3cdda;
+
+  /* Overlays */
+  --overlay-background: rgba(8, 12, 22, 0.72);
+  --overlay-strong: rgba(8, 12, 22, 0.85);
+
+  /* Accent-subtle fills (replace repeated low-alpha tints) */
+  --color-accent-subtle: rgba(59, 155, 255, 0.10);
+  --color-accent-subtle-strong: rgba(59, 155, 255, 0.16);
 
   /* Chart-specific colors */
   --chart-success: var(--color-success);
@@ -30,32 +50,32 @@
 
   /* Chart backgrounds */
   --chart-background: var(--color-surface);
-  --chart-grid: rgba(19, 127, 236, 0.12);
+  --chart-grid: rgba(154, 167, 184, 0.14);
 
   /* Chart data series colors */
   --chart-series-1: var(--color-primary);
   --chart-series-2: var(--color-secondary);
   --chart-series-3: var(--color-accent);
-  --chart-series-4: #0ea5e9;
-  --chart-series-5: #22c55e;
+  --chart-series-4: #34d399;
+  --chart-series-5: #a78bfa;
 
   /* Chart gradients */
-  --chart-gradient-primary: linear-gradient(180deg, rgba(19, 127, 236, 0.2) 0%, rgba(19, 127, 236, 0.05) 100%);
-  --chart-gradient-success: linear-gradient(180deg, rgba(15, 98, 184, 0.2) 0%, rgba(15, 98, 184, 0.05) 100%);
+  --chart-gradient-primary: linear-gradient(180deg, rgba(59, 155, 255, 0.28) 0%, rgba(59, 155, 255, 0.04) 100%);
+  --chart-gradient-success: linear-gradient(180deg, rgba(34, 197, 94, 0.26) 0%, rgba(34, 197, 94, 0.04) 100%);
 
   /* Glassmorphism */
-  --glass-background: rgba(255, 255, 255, 0.82);
-  --glass-border: rgba(19, 127, 236, 0.18);
+  --glass-background: rgba(17, 24, 39, 0.72);
+  --glass-border: rgba(255, 255, 255, 0.08);
   --glass-blur: blur(20px);
 
   /* Shadows */
-  --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
-  --shadow-sm: 0 4px 12px rgba(15, 23, 42, 0.06);
-  --shadow-md: 0 8px 24px rgba(15, 23, 42, 0.1);
-  --shadow-lg: 0 16px 40px rgba(15, 23, 42, 0.12);
-  --shadow-xl: 0 24px 60px rgba(15, 23, 42, 0.16);
-  --shadow-glow: 0 0 40px rgba(19, 127, 236, 0.18);
-  --shadow-glow-secondary: 0 0 40px rgba(15, 98, 184, 0.18);
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-sm: 0 4px 12px rgba(0, 0, 0, 0.45);
+  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.55);
+  --shadow-xl: 0 24px 60px rgba(0, 0, 0, 0.6);
+  --shadow-glow: 0 0 40px rgba(59, 155, 255, 0.22);
+  --shadow-glow-secondary: 0 0 40px rgba(47, 128, 237, 0.22);
 
   /* Layout */
   --radius-xs: 6px;
@@ -411,7 +431,7 @@ img {
 }
 
 .section--muted {
-  background: #eaf7f4;
+  background: var(--color-surface);
 }
 
 .section__inner {
@@ -443,7 +463,7 @@ img {
   font-size: 0.8rem;
   letter-spacing: 0.28em;
   font-weight: 700;
-  color: rgba(19, 127, 236, 0.7);
+  color: var(--color-primary);
   margin-bottom: 0.75rem;
 }
 
@@ -464,7 +484,7 @@ img {
 }
 
 .primary-button {
-  background: linear-gradient(135deg, #137fec, #2999ff);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
   color: #fff;
   box-shadow: 0 18px 30px rgba(19, 127, 236, 0.25);
 }
@@ -508,7 +528,7 @@ img {
 .card {
   background: var(--color-surface);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(19, 127, 236, 0.12);
+  border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
   padding: 1.75rem;
 }
@@ -550,7 +570,8 @@ img {
 .table thead th {
   position: sticky;
   top: var(--header-height);
-  z-index: 1;
+  z-index: 2;
+  background: var(--color-surface-elevated);
 }
 
 .table tbody tr:nth-child(even) {
@@ -579,23 +600,28 @@ img {
 }
 
 .tag--success {
-  background: rgba(16, 185, 129, 0.12);
-  color: #137fec;
+  background: var(--tag-success-bg);
+  color: var(--tag-success-text);
 }
 
 .tag--warning {
-  background: rgba(234, 179, 8, 0.16);
-  color: #92400e;
+  background: var(--tag-warning-bg);
+  color: var(--tag-warning-text);
+}
+
+.tag--error {
+  background: var(--tag-error-bg);
+  color: var(--tag-error-text);
 }
 
 .tag--info {
-  background: rgba(41, 153, 255, 0.15);
-  color: #075985;
+  background: var(--tag-info-bg);
+  color: var(--tag-info-text);
 }
 
 .tag--neutral {
-  background: rgba(107, 114, 128, 0.12);
-  color: #374151;
+  background: var(--tag-neutral-bg);
+  color: var(--tag-neutral-text);
 }
 
 .site-header {
@@ -604,9 +630,9 @@ img {
   left: 0;
   right: 0;
   z-index: 40;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--glass-background);
   backdrop-filter: blur(18px);
-  border-bottom: 1px solid rgba(19, 127, 236, 0.12);
+  border-bottom: 1px solid var(--glass-border);
 }
 
 .site-header__inner {
@@ -712,9 +738,10 @@ img {
 }
 
 .site-footer {
-  background: #0f172a;
-  color: #e5e7eb;
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
   padding: 3rem 1.5rem;
+  border-top: 1px solid var(--color-border);
 }
 
 .site-footer__inner {
@@ -732,16 +759,16 @@ img {
 }
 
 .site-footer__link {
-  color: rgba(229, 231, 235, 0.8);
+  color: var(--color-muted);
   display: block;
   margin-bottom: 0.65rem;
 }
 
 .hero {
   padding: 6rem 1.5rem 5rem;
-  background: radial-gradient(circle at top left, rgba(15, 98, 184, 0.2), transparent 55%),
-    radial-gradient(circle at top right, rgba(41, 153, 255, 0.16), transparent 50%),
-    linear-gradient(180deg, #ffffff 0%, #f0fdfa 100%);
+  background: radial-gradient(circle at top left, rgba(47, 128, 237, 0.22), transparent 55%),
+    radial-gradient(circle at top right, rgba(92, 176, 255, 0.16), transparent 50%),
+    linear-gradient(180deg, var(--color-surface) 0%, var(--color-background) 100%);
 }
 
 .hero__inner {
@@ -794,7 +821,7 @@ img {
   background: var(--color-surface);
   padding: 1.25rem 1.5rem;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(19, 127, 236, 0.12);
+  border: 1px solid var(--color-border);
   box-shadow: 0 15px 30px rgba(15, 23, 42, 0.06);
 }
 
@@ -819,8 +846,8 @@ img {
 .service-card {
   padding: 2rem;
   border-radius: var(--radius-lg);
-  background: linear-gradient(180deg, #ffffff 0%, #f0fdfa 100%);
-  border: 1px solid rgba(19, 127, 236, 0.1);
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-background) 100%);
+  border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
 }
 
@@ -1126,8 +1153,8 @@ img {
 .maintenance-card {
   padding: 1.5rem;
   border-radius: var(--radius-md);
-  background: linear-gradient(180deg, #ffffff 0%, #f2fbf7 100%);
-  border: 1px solid rgba(19, 127, 236, 0.12);
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-background) 100%);
+  border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
 }
 


### PR DESCRIPTION
## Summary
Converts the entire site to a single **default dark theme** and fixes the **sticky table-header bug** where data rows visually covered the header.

Built in three commits for a clean, reviewable diff:
1. **Baseline** — commits the previously-uncommitted teal→blue brand refresh on its own.
2. **Phase 1** — dark-theme infrastructure + the table fix + the dark-hostile "shell" components.
3. **Phase 2** — mechanical migration of the remaining ~278 hardcoded colors to tokens.

## The table-header bug (root cause)
The sticky element was the `<th>`, but it had **no background** — only its parent `<thead>` did. A transparent sticky cell let the zebra-striped `tbody` rows scroll *through* it. Fix: give the sticky `th` an opaque `background: var(--color-surface-elevated)` + `z-index: 2`, in the global `.table` rule and the 4 component copies (LedgerTable, TenantPortfolioTable, WorkOrderTable, MonthlyPaymentGrid). PaymentHistory uses the global rule.

## How dark theme works (no toggle)
The `:root` design tokens were redefined to dark values (`color-scheme: dark`). Because `html/body`, all charts (`lib/chart-config.ts`), and most components already consume `var(--color-*)`, the flip cascades site-wide for free. Added status-tag, overlay, and accent-subtle tokens; restored semantic status colors (`--color-success` back to green). Reworked the components that assumed a light background (site header glass, footer, `WeatherAlertsSection`, `TenantHero` card, `Card` loading overlay) and migrated the long tail of hardcoded colors. White-on-blue text (buttons/CTAs/badges) was deliberately preserved.

## Test plan
- [x] `npm run build` compiles clean
- [x] Detectors over `**/*.tsx` = 0: stale teal, invisible dark text (`#1e293b/#111827`), white surfaces (`white/#f8fafc`), off-brand purple
- [x] Rendered in mock mode (`NEXT_PUBLIC_USE_MOCK=true`): landing + portal are coherent dark, **0 white surfaces / 0 invisible text**
- [x] Sticky `th` verified in DOM: `position: sticky`, opaque `rgb(26,35,51)` background, `z-index: 2` — rows can no longer bleed through
- [ ] Reviewer spot-check of admin pages (auth-gated; not screenshotted here)

Note: `lib/email-templates.ts` keeps its teal palette intentionally — email HTML renders on white in mail clients, not in the dark web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)